### PR TITLE
Fix theme persistence script

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -16,8 +16,12 @@
   <script>
     window.API_URL = 'http://localhost:8080';
     const dark = localStorage.getItem('darkMode') === 'true';
-    document.getElementById('dark-theme')!.toggleAttribute('disabled', !dark);
-    document.getElementById('light-theme')!.toggleAttribute('disabled', dark);
+    const darkLink = document.getElementById('dark-theme');
+    const lightLink = document.getElementById('light-theme');
+    if (darkLink && lightLink) {
+      darkLink.toggleAttribute('disabled', !dark);
+      lightLink.toggleAttribute('disabled', dark);
+    }
   </script>
   <script src="bundle.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- correct dark theme initialization logic in index.html

## Testing
- `npm run build` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68472c126468832b960087555186204f