### PR TITLE
Add language toggle

### DIFF
--- a/frontend/src/app.module.ts
+++ b/frontend/src/app.module.ts
@@ -15,6 +15,9 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatCardModule } from '@angular/material/card';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatSelectModule } from '@angular/material/select';
+
+import { TranslatePipe } from './i18n/translate.pipe';
 
 import { AppComponent } from './app.component';
 import { NavbarComponent } from './navbar.component';
@@ -43,7 +46,8 @@ const routes: Routes = [
     UsersComponent,
     UserEditComponent,
     LoginComponent,
-    RegisterComponent
+    RegisterComponent,
+    TranslatePipe
   ],
   imports: [
     BrowserModule,
@@ -61,7 +65,8 @@ const routes: Routes = [
     MatIconModule,
     MatCheckboxModule,
     MatCardModule,
-    MatSlideToggleModule
+    MatSlideToggleModule,
+    MatSelectModule
   ],
   bootstrap: [AppComponent]
 })

--- a/frontend/src/dashboard.component.ts
+++ b/frontend/src/dashboard.component.ts
@@ -2,6 +2,6 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-dashboard',
-  template: `<p>Welcome to the dashboard.</p>`
+  template: `<p>{{ 'DASHBOARD_WELCOME' | t }}</p>`
 })
 export class DashboardComponent {}

--- a/frontend/src/i18n/translate.pipe.ts
+++ b/frontend/src/i18n/translate.pipe.ts
@@ -1,0 +1,10 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { TranslationService } from './translation.service';
+
+@Pipe({ name: 't', pure: false })
+export class TranslatePipe implements PipeTransform {
+  constructor(private ts: TranslationService) {}
+  transform(key: string, params?: Record<string, string | number>): string {
+    return this.ts.translate(key, params);
+  }
+}

--- a/frontend/src/i18n/translation.service.ts
+++ b/frontend/src/i18n/translation.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { translations } from './translations';
+
+export type Lang = 'en' | 'hu';
+
+@Injectable({ providedIn: 'root' })
+export class TranslationService {
+  lang: Lang = (localStorage.getItem('lang') as Lang) || 'en';
+
+  setLanguage(lang: Lang) {
+    this.lang = lang;
+    localStorage.setItem('lang', lang);
+  }
+
+  translate(key: string, params?: Record<string, string | number>): string {
+    const text = (translations as any)[this.lang]?.[key] || key;
+    if (params) {
+      return text.replace(/\{(\w+)\}/g, (_: string, p: string) => String(params[p] ?? ''));
+    }
+    return text;
+  }
+}

--- a/frontend/src/i18n/translations.ts
+++ b/frontend/src/i18n/translations.ts
@@ -1,0 +1,38 @@
+export const translations = {
+  en: {
+    LOGIN: 'Login',
+    REGISTER: 'Register',
+    USERNAME: 'Username',
+    PASSWORD: 'Password',
+    BACK_TO_LOGIN: 'Back to Login',
+    WELCOME: 'Welcome {username}',
+    DARK_MODE: 'Dark mode',
+    LOGOUT: 'Logout',
+    DASHBOARD: 'Dashboard',
+    USERS: 'Users',
+    DASHBOARD_WELCOME: 'Welcome to the dashboard.',
+    EDIT_USER: 'Edit {username}',
+    BACK: 'Back',
+    ID: 'ID',
+    NAME: 'Name',
+    ACTIONS: 'Actions'
+  },
+  hu: {
+    LOGIN: 'Bejelentkezés',
+    REGISTER: 'Regisztráció',
+    USERNAME: 'Felhasználónév',
+    PASSWORD: 'Jelszó',
+    BACK_TO_LOGIN: 'Vissza a bejelentkezéshez',
+    WELCOME: 'Üdv {username}',
+    DARK_MODE: 'Sötét mód',
+    LOGOUT: 'Kijelentkezés',
+    DASHBOARD: 'Kezdőlap',
+    USERS: 'Felhasználók',
+    DASHBOARD_WELCOME: 'Üdvözöljük a vezérlőpulton.',
+    EDIT_USER: '{username} szerkesztése',
+    BACK: 'Vissza',
+    ID: 'Azonosító',
+    NAME: 'Név',
+    ACTIONS: 'Műveletek'
+  }
+} as const;

--- a/frontend/src/login.component.ts
+++ b/frontend/src/login.component.ts
@@ -8,20 +8,20 @@ import { User } from './app.component';
   template: `
     <div class="login">
       <mat-card>
-        <mat-card-title>Login</mat-card-title>
+        <mat-card-title>{{ 'LOGIN' | t }}</mat-card-title>
         <mat-card-content>
           <mat-form-field appearance="fill">
-            <mat-label>Username</mat-label>
+            <mat-label>{{ 'USERNAME' | t }}</mat-label>
             <input matInput [(ngModel)]="username">
           </mat-form-field>
           <mat-form-field appearance="fill">
-            <mat-label>Password</mat-label>
+            <mat-label>{{ 'PASSWORD' | t }}</mat-label>
             <input matInput type="password" [(ngModel)]="password">
           </mat-form-field>
         </mat-card-content>
         <mat-card-actions>
-          <button mat-raised-button color="primary" (click)="login()">Login</button>
-          <a mat-button routerLink="/register">Register</a>
+          <button mat-raised-button color="primary" (click)="login()">{{ 'LOGIN' | t }}</button>
+          <a mat-button routerLink="/register">{{ 'REGISTER' | t }}</a>
         </mat-card-actions>
       </mat-card>
     </div>

--- a/frontend/src/navbar.component.ts
+++ b/frontend/src/navbar.component.ts
@@ -5,8 +5,8 @@ import { User } from './app.component';
   selector: 'app-navbar',
   template: `
     <mat-nav-list>
-      <a mat-list-item routerLink="/dashboard" routerLinkActive="active" *ngIf="hasPrivilege('dashboard')">Dashboard</a>
-      <a mat-list-item routerLink="/users" routerLinkActive="active" *ngIf="hasPrivilege('users')">Users</a>
+      <a mat-list-item routerLink="/dashboard" routerLinkActive="active" *ngIf="hasPrivilege('dashboard')">{{ 'DASHBOARD' | t }}</a>
+      <a mat-list-item routerLink="/users" routerLinkActive="active" *ngIf="hasPrivilege('users')">{{ 'USERS' | t }}</a>
     </mat-nav-list>
   `,
   styles: [`

--- a/frontend/src/register.component.ts
+++ b/frontend/src/register.component.ts
@@ -7,20 +7,20 @@ import { AuthService } from './auth.service';
   template: `
     <div class="register">
       <mat-card>
-        <mat-card-title>Register</mat-card-title>
+        <mat-card-title>{{ 'REGISTER' | t }}</mat-card-title>
         <mat-card-content>
           <mat-form-field appearance="fill">
-            <mat-label>Username</mat-label>
+            <mat-label>{{ 'USERNAME' | t }}</mat-label>
             <input matInput [(ngModel)]="username">
           </mat-form-field>
           <mat-form-field appearance="fill">
-            <mat-label>Password</mat-label>
+            <mat-label>{{ 'PASSWORD' | t }}</mat-label>
             <input matInput type="password" [(ngModel)]="password">
           </mat-form-field>
         </mat-card-content>
         <mat-card-actions>
-          <button mat-raised-button color="primary" (click)="register()">Register</button>
-          <a mat-button routerLink="/login">Back to Login</a>
+          <button mat-raised-button color="primary" (click)="register()">{{ 'REGISTER' | t }}</button>
+          <a mat-button routerLink="/login">{{ 'BACK_TO_LOGIN' | t }}</a>
         </mat-card-actions>
       </mat-card>
     </div>

--- a/frontend/src/top-menu.component.ts
+++ b/frontend/src/top-menu.component.ts
@@ -1,14 +1,19 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { User } from './app.component';
+import { TranslationService, Lang } from './i18n/translation.service';
 
 @Component({
   selector: 'app-top-menu',
   template: `
     <mat-toolbar color="primary">
-      <span *ngIf="user" class="user">Welcome {{user.username}}</span>
-      <mat-slide-toggle [(ngModel)]="dark" (change)="toggleDark()">Dark mode</mat-slide-toggle>
+      <span *ngIf="user" class="user">{{ 'WELCOME' | t:{username: user?.username} }}</span>
+      <mat-slide-toggle [(ngModel)]="dark" (change)="toggleDark()">{{ 'DARK_MODE' | t }}</mat-slide-toggle>
+      <mat-select [(ngModel)]="lang" (selectionChange)="changeLang($event.value)">
+        <mat-option value="en">EN</mat-option>
+        <mat-option value="hu">HU</mat-option>
+      </mat-select>
       <span class="spacer"></span>
-      <button mat-button *ngIf="user" (click)="logout.emit()">Logout</button>
+      <button mat-button *ngIf="user" (click)="logout.emit()">{{ 'LOGOUT' | t }}</button>
     </mat-toolbar>
   `,
   styles: [`
@@ -20,6 +25,11 @@ export class TopMenuComponent {
   @Input() user?: User;
   @Output() logout = new EventEmitter<void>();
   dark = localStorage.getItem('darkMode') === 'true';
+  lang: Lang;
+
+  constructor(private ts: TranslationService) {
+    this.lang = this.ts.lang;
+  }
 
   toggleDark() {
     localStorage.setItem('darkMode', String(this.dark));
@@ -29,5 +39,10 @@ export class TopMenuComponent {
       darkLink.disabled = !this.dark;
       lightLink.disabled = this.dark;
     }
+  }
+
+  changeLang(l: Lang) {
+    this.ts.setLanguage(l);
+    this.lang = l;
   }
 }

--- a/frontend/src/user-edit.component.ts
+++ b/frontend/src/user-edit.component.ts
@@ -7,7 +7,7 @@ import { User, Privilege } from './app.component';
   selector: 'app-user-edit',
   template: `
     <mat-card *ngIf="user" class="user-card">
-      <mat-card-title>Edit {{user.username}}</mat-card-title>
+      <mat-card-title>{{ 'EDIT_USER' | t:{username: user?.username} }}</mat-card-title>
       <mat-card-content>
         <div class="priv" *ngFor="let p of allPrivileges">
           <mat-checkbox [checked]="hasPrivilege(p)" (change)="togglePrivilege(p, $event)">
@@ -18,7 +18,7 @@ import { User, Privilege } from './app.component';
       <mat-card-actions>
         <button mat-stroked-button color="primary" routerLink="/users">
           <mat-icon>arrow_back</mat-icon>
-          Back
+          {{ 'BACK' | t }}
         </button>
       </mat-card-actions>
     </mat-card>

--- a/frontend/src/users.component.ts
+++ b/frontend/src/users.component.ts
@@ -10,15 +10,15 @@ import { User } from './app.component';
   template: `
     <table mat-table [dataSource]="dataSource" class="mat-elevation-z8 clickable">
       <ng-container matColumnDef="id">
-        <th mat-header-cell *matHeaderCellDef>ID</th>
+        <th mat-header-cell *matHeaderCellDef>{{ 'ID' | t }}</th>
         <td mat-cell *matCellDef="let u" (click)="editUser(u.id)">{{u.id}}</td>
       </ng-container>
       <ng-container matColumnDef="username">
-        <th mat-header-cell *matHeaderCellDef>Name</th>
+        <th mat-header-cell *matHeaderCellDef>{{ 'NAME' | t }}</th>
         <td mat-cell *matCellDef="let u" (click)="editUser(u.id)">{{u.username}}</td>
       </ng-container>
       <ng-container matColumnDef="actions">
-        <th mat-header-cell *matHeaderCellDef>Actions</th>
+        <th mat-header-cell *matHeaderCellDef>{{ 'ACTIONS' | t }}</th>
         <td mat-cell *matCellDef="let u">
           <button mat-icon-button color="warn" (click)="deleteUser(u.id)">
             <mat-icon>delete</mat-icon>


### PR DESCRIPTION
## Summary
- add a simple i18n service with English and Hungarian translations
- update components to use translation pipe
- add language selector in the top menu

## Testing
- `npm run build`
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68478071cc7c832b88b2e6fd25c4fd5a