### PR TITLE
Improve language selector position

### DIFF
--- a/frontend/src/top-menu.component.ts
+++ b/frontend/src/top-menu.component.ts
@@ -8,17 +8,18 @@ import { TranslationService, Lang } from './i18n/translation.service';
     <mat-toolbar color="primary">
       <span *ngIf="user" class="user">{{ 'WELCOME' | t:{username: user?.username} }}</span>
       <mat-slide-toggle [(ngModel)]="dark" (change)="toggleDark()">{{ 'DARK_MODE' | t }}</mat-slide-toggle>
-      <mat-select [(ngModel)]="lang" (selectionChange)="changeLang($event.value)">
+      <span class="spacer"></span>
+      <mat-select class="lang" [(ngModel)]="lang" (selectionChange)="changeLang($event.value)">
         <mat-option value="en">EN</mat-option>
         <mat-option value="hu">HU</mat-option>
       </mat-select>
-      <span class="spacer"></span>
       <button mat-button *ngIf="user" (click)="logout.emit()">{{ 'LOGOUT' | t }}</button>
     </mat-toolbar>
   `,
   styles: [`
     .spacer { flex: 1 1 auto; }
     .user { margin-right: 1rem; }
+    .lang { width: 60px; margin-right: .5rem; }
   `]
 })
 export class TopMenuComponent {


### PR DESCRIPTION
## Summary
- keep logout button right-aligned
- place the language selector next to logout with a narrow width

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68478eadb9d0832b91bf67dc3f5222bc