### PR TITLE
Add Kubernetes structure and Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,61 @@
+pipeline {
+    agent any
+    environment {
+        REGISTRY = "myregistry"
+        IMAGE_BACKEND = "${REGISTRY}/codex-backend:${env.BUILD_NUMBER}"
+        IMAGE_FRONTEND = "${REGISTRY}/codex-frontend:${env.BUILD_NUMBER}"
+    }
+    stages {
+        stage('Checkout') {
+            steps {
+                checkout scm
+            }
+        }
+        stage('Backend Tests') {
+            steps {
+                dir('backend') {
+                    sh './gradlew test --no-daemon'
+                }
+            }
+        }
+        stage('Frontend Build') {
+            steps {
+                dir('frontend') {
+                    sh 'npm install'
+                    sh 'npm run build'
+                }
+            }
+        }
+        stage('Build Images') {
+            steps {
+                sh 'docker build -t $IMAGE_BACKEND ./backend'
+                sh 'docker build -t $IMAGE_FRONTEND ./frontend'
+                sh 'docker push $IMAGE_BACKEND'
+                sh 'docker push $IMAGE_FRONTEND'
+            }
+        }
+        stage('Deploy to dev') {
+            steps {
+                sh 'kubectl apply -f kubernetes/dev'
+            }
+        }
+        stage('Deploy to staging') {
+            when {
+                branch 'main'
+            }
+            steps {
+                input message: 'Deploy to staging?'
+                sh 'kubectl apply -f kubernetes/staging'
+            }
+        }
+        stage('Deploy to prod') {
+            when {
+                branch 'main'
+            }
+            steps {
+                input message: 'Deploy to production?'
+                sh 'kubectl apply -f kubernetes/prod'
+            }
+        }
+    }
+}

--- a/KUBERNETES.md
+++ b/KUBERNETES.md
@@ -1,0 +1,46 @@
+# Managing Environments in Kubernetes
+
+This project currently uses Docker Compose for local development. To manage different environments (development, staging, production) in Kubernetes, you can organize resources using namespaces or separate clusters.
+
+## Example Setup
+
+1. **Namespaces**: Create a namespace for each environment.
+   ```bash
+   kubectl create namespace codex-dev
+   kubectl create namespace codex-staging
+   kubectl create namespace codex-prod
+   ```
+   Deploy the backend and frontend to the appropriate namespace. Use separate configuration files (e.g., `deployment-dev.yaml`, `deployment-staging.yaml`, `deployment-prod.yaml`) that reference the correct Docker images and environment variables.
+
+2. **Helm**: Use Helm charts to manage templated configurations across environments. Values files (`values-dev.yaml`, `values-staging.yaml`, `values-prod.yaml`) let you customize settings per environment while reusing the same chart structure.
+
+3. **CI/CD Integration**: Configure your CI/CD pipeline to build Docker images and deploy them using `kubectl` or Helm for each environment. Tools like GitHub Actions, GitLab CI, or Jenkins can orchestrate these steps.
+
+## Recommended Directory Structure
+
+```
+kubernetes/
+├── dev/
+│   ├── backend-deployment.yaml
+│   ├── frontend-deployment.yaml
+│   └── ...
+├── staging/
+│   ├── backend-deployment.yaml
+│   ├── frontend-deployment.yaml
+│   └── ...
+└── prod/
+    ├── backend-deployment.yaml
+    ├── frontend-deployment.yaml
+    └── ...
+```
+
+Each folder contains the Kubernetes manifests or Helm values specific to that environment.
+
+## Jenkins Pipeline
+
+A simple [Jenkinsfile](Jenkinsfile) is included to build Docker images, push them to a
+registry, and deploy the manifests from the `kubernetes/` directory. The pipeline
+runs tests, builds the frontend and backend containers, and applies the files for the
+`dev`, `staging`, and `prod` namespaces.
+
+Refer to the official [Kubernetes documentation](https://kubernetes.io/docs/home/) for additional best practices.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ docker-compose up --build
 ```
 
 The backend will be on `http://localhost:8080` and the frontend on `http://localhost:4200`.
+
+## Managing Environments in Kubernetes
+
+For deployments beyond local development, you can manage separate environments (development, staging, production) using Kubernetes. See [KUBERNETES.md](KUBERNETES.md) for a basic overview and example structure. A sample Jenkins pipeline is provided in the [Jenkinsfile](Jenkinsfile) to automate builds and deployments.

--- a/kubernetes/dev/backend-deployment.yaml
+++ b/kubernetes/dev/backend-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: codex-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: codex-backend
+  template:
+    metadata:
+      labels:
+        app: codex-backend
+    spec:
+      containers:
+        - name: backend
+          image: myregistry/codex-backend:latest
+          ports:
+            - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: codex-backend
+spec:
+  selector:
+    app: codex-backend
+  ports:
+    - port: 80
+      targetPort: 8080

--- a/kubernetes/dev/frontend-deployment.yaml
+++ b/kubernetes/dev/frontend-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: codex-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: codex-frontend
+  template:
+    metadata:
+      labels:
+        app: codex-frontend
+    spec:
+      containers:
+        - name: frontend
+          image: myregistry/codex-frontend:latest
+          ports:
+            - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: codex-frontend
+spec:
+  selector:
+    app: codex-frontend
+  ports:
+    - port: 80
+      targetPort: 80

--- a/kubernetes/prod/backend-deployment.yaml
+++ b/kubernetes/prod/backend-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: codex-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: codex-backend
+  template:
+    metadata:
+      labels:
+        app: codex-backend
+    spec:
+      containers:
+        - name: backend
+          image: myregistry/codex-backend:latest
+          ports:
+            - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: codex-backend
+spec:
+  selector:
+    app: codex-backend
+  ports:
+    - port: 80
+      targetPort: 8080

--- a/kubernetes/prod/frontend-deployment.yaml
+++ b/kubernetes/prod/frontend-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: codex-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: codex-frontend
+  template:
+    metadata:
+      labels:
+        app: codex-frontend
+    spec:
+      containers:
+        - name: frontend
+          image: myregistry/codex-frontend:latest
+          ports:
+            - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: codex-frontend
+spec:
+  selector:
+    app: codex-frontend
+  ports:
+    - port: 80
+      targetPort: 80

--- a/kubernetes/staging/backend-deployment.yaml
+++ b/kubernetes/staging/backend-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: codex-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: codex-backend
+  template:
+    metadata:
+      labels:
+        app: codex-backend
+    spec:
+      containers:
+        - name: backend
+          image: myregistry/codex-backend:latest
+          ports:
+            - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: codex-backend
+spec:
+  selector:
+    app: codex-backend
+  ports:
+    - port: 80
+      targetPort: 8080

--- a/kubernetes/staging/frontend-deployment.yaml
+++ b/kubernetes/staging/frontend-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: codex-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: codex-frontend
+  template:
+    metadata:
+      labels:
+        app: codex-frontend
+    spec:
+      containers:
+        - name: frontend
+          image: myregistry/codex-frontend:latest
+          ports:
+            - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: codex-frontend
+spec:
+  selector:
+    app: codex-frontend
+  ports:
+    - port: 80
+      targetPort: 80


### PR DESCRIPTION
## Summary
- add example Kubernetes manifests for dev/staging/prod
- mention Jenkins pipeline in docs
- provide Jenkinsfile for building and deploying images

## Testing
- `timeout 30 ./gradlew test --no-daemon` *(stuck, logs show daemon starting)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847a0b0eb94832b92128a0bcd594f24