### PR TITLE
Add Jenkins agent Dockerfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,10 @@
 pipeline {
     agent any
     environment {
-        REGISTRY = "myregistry"
-        IMAGE_BACKEND = "${REGISTRY}/codex-backend:${env.BUILD_NUMBER}"
-        IMAGE_FRONTEND = "${REGISTRY}/codex-frontend:${env.BUILD_NUMBER}"
+        // use the Docker Compose service name and port
+        REGISTRY         = "registry:5000"
+        IMAGE_BACKEND    = "${REGISTRY}/codex-backend:${env.BUILD_NUMBER}"
+        IMAGE_FRONTEND   = "${REGISTRY}/codex-frontend:${env.BUILD_NUMBER}"
     }
     stages {
         stage('Checkout') {
@@ -26,12 +27,14 @@ pipeline {
                 }
             }
         }
-        stage('Build Images') {
+        stage('Build & Push Images') {
             steps {
-                sh 'docker build -t $IMAGE_BACKEND ./backend'
-                sh 'docker build -t $IMAGE_FRONTEND ./frontend'
-                sh 'docker push $IMAGE_BACKEND'
-                sh 'docker push $IMAGE_FRONTEND'
+                sh """
+                   docker build -t $IMAGE_BACKEND ./backend
+                   docker build -t $IMAGE_FRONTEND ./frontend
+                   docker push $IMAGE_BACKEND
+                   docker push $IMAGE_FRONTEND
+                """
             }
         }
         stage('Deploy to dev') {
@@ -40,18 +43,14 @@ pipeline {
             }
         }
         stage('Deploy to staging') {
-            when {
-                branch 'main'
-            }
+            when { branch 'main' }
             steps {
                 input message: 'Deploy to staging?'
                 sh 'kubectl apply -f kubernetes/staging'
             }
         }
         stage('Deploy to prod') {
-            when {
-                branch 'main'
-            }
+            when { branch 'main' }
             steps {
                 input message: 'Deploy to production?'
                 sh 'kubectl apply -f kubernetes/prod'

--- a/README.md
+++ b/README.md
@@ -24,3 +24,13 @@ The backend will be on `http://localhost:8080` and the frontend on `http://local
 ## Managing Environments in Kubernetes
 
 For deployments beyond local development, you can manage separate environments (development, staging, production) using Kubernetes. See [KUBERNETES.md](KUBERNETES.md) for a basic overview and example structure. A sample Jenkins pipeline is provided in the [Jenkinsfile](Jenkinsfile) to automate builds and deployments.
+
+## Jenkins Build Environment
+
+A Dockerfile is provided under `jenkins/` to build a Jenkins agent image with Node.js, the Docker CLI and `kubectl` installed. Build it with:
+
+```bash
+docker build -t codex-jenkins-agent ./jenkins
+```
+
+Use this image in your Jenkins setup to run the pipeline defined in `Jenkinsfile`.

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,0 +1,35 @@
+FROM jenkins/jenkins:lts-jdk17
+
+USER root
+
+# Install required packages
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        gnupg2 \
+        lsb-release \
+        git \
+        software-properties-common && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Docker CLI
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
+    add-apt-repository \
+        "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends docker-ce-cli && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Node.js
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install kubectl
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+    install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
+    rm kubectl
+
+USER jenkins

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,35 +1,9 @@
-FROM jenkins/jenkins:lts-jdk17
+FROM jenkins/jenkins:lts
 
 USER root
-
-# Install required packages
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        apt-transport-https \
-        ca-certificates \
-        curl \
-        gnupg2 \
-        lsb-release \
-        git \
-        software-properties-common && \
-    rm -rf /var/lib/apt/lists/*
-
-# Install Docker CLI
-RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
-    add-apt-repository \
-        "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends docker-ce-cli && \
-    rm -rf /var/lib/apt/lists/*
-
-# Install Node.js
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
-    apt-get install -y --no-install-recommends nodejs && \
-    rm -rf /var/lib/apt/lists/*
-
-# Install kubectl
-RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
-    install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
-    rm kubectl
-
+RUN apt-get update \
+ && apt-get install -y docker.io \
+ && rm -rf /var/lib/apt/lists/* \
+ && groupadd -g 999 docker  || true \
+ && usermod -aG docker jenkins
 USER jenkins

--- a/jenkins/docker-compose.yml
+++ b/jenkins/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3.8'
+
+services:
+  jenkins:
+    image: codex-jenkins-agent:latest
+    container_name: jenkins
+    user: root
+    ports:
+      - "8080:8080"
+      - "50000:50000"
+    environment:
+      # Point Jenkins (and its Docker CLI) to the host Docker daemon
+      DOCKER_HOST: "tcp://host.docker.internal:2375"
+      # (Optional) if you want to expose the registry URL inside Jenkins jobs
+      REGISTRY_URL: "http://registry:5000"
+    volumes:
+      - jenkins_home:/var/jenkins_home
+    depends_on:
+      - registry
+    restart: unless-stopped
+
+  registry:
+    image: registry:2
+    container_name: local-registry
+    ports:
+      - "5000:5000"
+    restart: unless-stopped
+
+volumes:
+  jenkins_home:
+    driver: local


### PR DESCRIPTION
## Summary
- add a Dockerfile for Jenkins jobs
- document Jenkins build environment in the README

## Testing
- `./gradlew test --no-daemon`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847aa6fc780832b9175d12e8a1df467