### PR TITLE
Add frontend excel export

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.0",
         "tslib": "^2.5.0",
+        "xlsx": "^0.18.5",
         "zone.js": "^0.13.3"
       },
       "devDependencies": {
@@ -1633,6 +1634,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
@@ -1920,6 +1930,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1985,6 +2008,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/color-convert": {
@@ -2116,6 +2148,18 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2619,6 +2663,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fresh": {
@@ -4460,6 +4513,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -5035,6 +5100,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -5062,6 +5145,27 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/zone.js": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,8 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.0",
     "tslib": "^2.5.0",
-    "zone.js": "^0.13.3"
+    "zone.js": "^0.13.3",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "ts-loader": "^9.4.2",

--- a/frontend/src/app.module.ts
+++ b/frontend/src/app.module.ts
@@ -27,6 +27,7 @@ import { UsersComponent } from './users.component';
 import { UserEditComponent } from './user-edit.component';
 import { LoginComponent } from './login.component';
 import { RegisterComponent } from './register.component';
+import { CostSplitComponent } from './cost-split.component';
 
 const routes: Routes = [
   { path: 'login', component: LoginComponent },
@@ -34,6 +35,7 @@ const routes: Routes = [
   { path: 'dashboard', component: DashboardComponent },
   { path: 'users', component: UsersComponent },
   { path: 'users/:id', component: UserEditComponent },
+  { path: 'cost-split', component: CostSplitComponent },
   { path: '', redirectTo: 'login', pathMatch: 'full' }
 ];
 
@@ -47,6 +49,7 @@ const routes: Routes = [
     UserEditComponent,
     LoginComponent,
     RegisterComponent,
+    CostSplitComponent,
     TranslatePipe
   ],
   imports: [

--- a/frontend/src/cost-split.component.ts
+++ b/frontend/src/cost-split.component.ts
@@ -1,0 +1,158 @@
+import { Component } from '@angular/core';
+import * as XLSX from 'xlsx';
+import { TranslationService } from './i18n/translation.service';
+
+@Component({
+  selector: 'app-cost-split',
+  template: `
+    <mat-card class="cost-card">
+      <mat-card-title>{{ 'COST_SPLIT' | t }}</mat-card-title>
+      <mat-card-content>
+        <div class="form-row">
+          <mat-form-field appearance="fill">
+            <mat-label>{{ 'START_DATE' | t }}</mat-label>
+            <input matInput [(ngModel)]="startDate" placeholder="20231201">
+          </mat-form-field>
+          <mat-form-field appearance="fill">
+            <mat-label>{{ 'END_DATE' | t }}</mat-label>
+            <input matInput [(ngModel)]="endDate" placeholder="20240110">
+          </mat-form-field>
+          <mat-form-field appearance="fill">
+            <mat-label>{{ 'CURRENT_YEAR_LAST_DAY' | t }}</mat-label>
+            <input matInput [(ngModel)]="currentYearLastDay" placeholder="20231231">
+          </mat-form-field>
+          <mat-form-field appearance="fill">
+            <mat-label>{{ 'AMOUNT' | t }}</mat-label>
+            <input matInput [(ngModel)]="amount" placeholder="10000,50">
+          </mat-form-field>
+        </div>
+      </mat-card-content>
+      <mat-card-actions>
+        <button mat-raised-button color="primary" (click)="calculate()">{{ 'CALCULATE' | t }}</button>
+        <button mat-raised-button color="accent" (click)="exportExcel()" [disabled]="!yearBreakdown.length">{{ 'EXPORT_EXCEL' | t }}</button>
+      </mat-card-actions>
+      <mat-card-content *ngIf="totalDays !== undefined">
+        <p>{{ 'TOTAL_DAYS' | t }}: {{ totalDays }}</p>
+        <table class="result-table">
+          <thead>
+            <tr>
+              <th>{{ 'YEAR' | t }}</th>
+              <th>{{ 'DAYS' | t }}</th>
+              <th>{{ 'AMOUNT' | t }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let r of yearBreakdown">
+              <td>{{ r.year }}</td>
+              <td>{{ r.days }}</td>
+              <td>{{ r.amount }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </mat-card-content>
+    </mat-card>
+  `,
+  styles: [`
+    .cost-card { max-width: 600px; margin: 1rem auto; display: block; }
+    .form-row { display: flex; flex-direction: column; gap: 0.5rem; }
+    .result-table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+    .result-table th, .result-table td { border: 1px solid #ccc; padding: 0.25rem 0.5rem; }
+  `]
+})
+export class CostSplitComponent {
+  startDate = '20231201';
+  endDate = '20240110';
+  currentYearLastDay = '20231231';
+  amount = '10000,50';
+
+  totalDays?: number;
+  yearBreakdown: { year: number; days: number; amount: string }[] = [];
+
+  constructor(private ts: TranslationService) {}
+
+  private parseDate(s: string): Date {
+    if (!/^(\d{8})$/.test(s)) throw new Error('bad date');
+    const y = Number(s.slice(0, 4));
+    const m = Number(s.slice(4, 6)) - 1;
+    const d = Number(s.slice(6, 8));
+    return new Date(y, m, d);
+  }
+
+  calculate() {
+    try {
+      const start = this.parseDate(this.startDate);
+      const end = this.parseDate(this.endDate);
+      const last = this.parseDate(this.currentYearLastDay);
+
+      const amountNum = parseFloat(this.amount.replace(',', '.'));
+      if (isNaN(amountNum)) throw new Error('amount');
+
+      if (start > end) {
+        alert('Az időszak kezdő dátuma nem lehet később, mint a befejező dátuma.');
+        return;
+      }
+
+      const diff = Math.floor((end.getTime() - start.getTime()) / 86400000) + 1;
+      if (diff <= 0) {
+        alert('Az összes napok száma nulla vagy negatív. Ellenőrizd a dátumokat.');
+        return;
+      }
+
+      this.totalDays = diff;
+      this.yearBreakdown = [];
+
+      const dayMs = 24 * 60 * 60 * 1000;
+
+      // first segment up to provided last day
+      let segStart = start;
+      let segEnd = last < end ? last : end;
+      if (segEnd >= segStart) {
+        const days = Math.floor((segEnd.getTime() - segStart.getTime()) / dayMs) + 1;
+        this.yearBreakdown.push({
+          year: segStart.getFullYear(),
+          days,
+          amount: ((amountNum / diff) * days).toFixed(2).replace('.', ',')
+        });
+      }
+
+      segStart = new Date(segEnd.getTime() + dayMs);
+
+      while (segStart <= end) {
+        const year = segStart.getFullYear();
+        segEnd = new Date(year, 11, 31);
+        if (segEnd > end) segEnd = end;
+        const days = Math.floor((segEnd.getTime() - segStart.getTime()) / dayMs) + 1;
+        this.yearBreakdown.push({
+          year,
+          days,
+          amount: ((amountNum / diff) * days).toFixed(2).replace('.', ',')
+        });
+        segStart = new Date(segEnd.getTime() + dayMs);
+      }
+    } catch (e: any) {
+      if (e.message === 'bad date') {
+        alert("Hibás dátumformátum. Kérlek 'ÉÉÉÉHHNN' formátumot használj.");
+      } else if (e.message === 'amount') {
+        alert('Hibás összeg formátum. Kérlek számot adj meg.');
+      } else {
+        alert('Ismeretlen hiba történt.');
+      }
+      this.totalDays = undefined;
+      this.yearBreakdown = [];
+    }
+  }
+
+  exportExcel() {
+    if (!this.yearBreakdown.length) return;
+    const data: any[][] = [];
+    data.push([this.ts.translate('TOTAL_DAYS'), this.totalDays ?? 0]);
+    data.push([this.ts.translate('YEAR'), this.ts.translate('DAYS'), this.ts.translate('AMOUNT')]);
+    for (const r of this.yearBreakdown) {
+      data.push([r.year, r.days, r.amount]);
+    }
+    const ws = XLSX.utils.aoa_to_sheet(data);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Result');
+    XLSX.writeFile(wb, 'cost_split.xlsx');
+  }
+}

--- a/frontend/src/i18n/translations.ts
+++ b/frontend/src/i18n/translations.ts
@@ -15,7 +15,21 @@ export const translations = {
     BACK: 'Back',
     ID: 'ID',
     NAME: 'Name',
-    ACTIONS: 'Actions'
+    ACTIONS: 'Actions',
+    COST_SPLIT: 'Period Cost Allocation',
+    START_DATE: 'Start date (YYYYMMDD)',
+    END_DATE: 'End date (YYYYMMDD)',
+    CURRENT_YEAR_LAST_DAY: 'Current year last day (YYYYMMDD)',
+    AMOUNT: 'Amount',
+    CALCULATE: 'Calculate',
+    TOTAL_DAYS: 'Total days',
+    CURRENT_YEAR_DAYS: 'Current year days',
+    NEXT_YEAR_DAYS: 'Next year days',
+    CURRENT_YEAR_AMOUNT: 'Current year amount',
+    NEXT_YEAR_AMOUNT: 'Next year amount',
+    EXPORT_EXCEL: 'Export to Excel',
+    YEAR: 'Year',
+    DAYS: 'Days'
   },
   hu: {
     LOGIN: 'Bejelentkezés',
@@ -33,6 +47,20 @@ export const translations = {
     BACK: 'Vissza',
     ID: 'Azonosító',
     NAME: 'Név',
-    ACTIONS: 'Műveletek'
+    ACTIONS: 'Műveletek',
+    COST_SPLIT: 'Időszaki költségfelosztó',
+    START_DATE: 'Kezdő dátum (ÉÉÉÉHHNN)',
+    END_DATE: 'Befejező dátum (ÉÉÉÉHHNN)',
+    CURRENT_YEAR_LAST_DAY: 'Tárgyév utolsó napja (ÉÉÉÉHHNN)',
+    AMOUNT: 'Összeg',
+    CALCULATE: 'Számítás',
+    TOTAL_DAYS: 'Összes napok száma',
+    CURRENT_YEAR_DAYS: 'Tárgyévi napok száma',
+    NEXT_YEAR_DAYS: 'Következő évi napok száma',
+    CURRENT_YEAR_AMOUNT: 'Tárgyévi összeg',
+    NEXT_YEAR_AMOUNT: 'Következő évi összeg',
+    EXPORT_EXCEL: 'Excel export',
+    YEAR: 'Év',
+    DAYS: 'Napok'
   }
 } as const;

--- a/frontend/src/navbar.component.ts
+++ b/frontend/src/navbar.component.ts
@@ -7,6 +7,7 @@ import { User } from './app.component';
     <mat-nav-list>
       <a mat-list-item routerLink="/dashboard" routerLinkActive="active" *ngIf="hasPrivilege('dashboard')">{{ 'DASHBOARD' | t }}</a>
       <a mat-list-item routerLink="/users" routerLinkActive="active" *ngIf="hasPrivilege('users')">{{ 'USERS' | t }}</a>
+      <a mat-list-item routerLink="/cost-split" routerLinkActive="active">{{ 'COST_SPLIT' | t }}</a>
     </mat-nav-list>
   `,
   styles: [`


### PR DESCRIPTION
## Summary
- add Excel export to period cost calculator
- wire up i18n keys for export button
- include xlsx dependency
- improve cost split component to handle multi-year periods

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68496f84dff0832bb4b1a0d52563b394