### PR TITLE
Parameterize config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,10 @@ pipeline {
     REGISTRY_URL   = "host.docker.internal:5000"
     IMAGE_BACKEND  = "${REGISTRY_URL}/codex-backend:${env.BUILD_NUMBER}"
     IMAGE_FRONTEND = "${REGISTRY_URL}/codex-frontend:${env.BUILD_NUMBER}"
+    DB_HOST        = 'codex-db'
+    DB_PORT        = '5432'
+    BACKEND_PORT   = '8080'
+    FRONTEND_URL   = 'http://localhost:30080'
   }
 
   stages {
@@ -43,9 +47,13 @@ pipeline {
       steps {
         script {
 		  // Export both images with the current BUILD_NUMBER
-		  sh '''
-			export IMAGE_BACKEND=${REGISTRY_URL}/codex-backend:${BUILD_NUMBER}
-			export IMAGE_FRONTEND=${REGISTRY_URL}/codex-frontend:${BUILD_NUMBER}
+                  sh '''
+                        export IMAGE_BACKEND=${REGISTRY_URL}/codex-backend:${BUILD_NUMBER}
+                        export IMAGE_FRONTEND=${REGISTRY_URL}/codex-frontend:${BUILD_NUMBER}
+                        export DB_HOST=${DB_HOST}
+                        export DB_PORT=${DB_PORT}
+                        export BACKEND_PORT=${BACKEND_PORT}
+                        export FRONTEND_URL=${FRONTEND_URL}
 
 			# Render & apply backend YAML
 			envsubst < kubernetes/dev/backend-deployment.yaml | kubectl apply -f -

--- a/backend/src/main/kotlin/com/example/codex/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/com/example/codex/config/SecurityConfig.kt
@@ -15,12 +15,15 @@ import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.web.cors.CorsConfiguration
+import org.springframework.beans.factory.annotation.Value
 
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
 class SecurityConfig(
-    private val userService: UserService
+    private val userService: UserService,
+    @Value("\${FRONTEND_URL:http://localhost:30080}")
+    private val frontendUrl: String
 ) {
 
     companion object {
@@ -58,7 +61,7 @@ class SecurityConfig(
             .cors {
                 it.configurationSource { request ->
                     CorsConfiguration().apply {
-                        allowedOrigins = listOf("http://localhost:30080")
+                        allowedOrigins = listOf(frontendUrl)
                         allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
                         allowedHeaders = listOf("*")
                         allowCredentials = true

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -8,3 +8,6 @@ spring:
 
 logging.level.org.jooq.tools.LoggerListener: DEBUG
 
+server:
+  port: ${SERVER_PORT:8080}
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,18 +7,21 @@ services:
       POSTGRES_USER: codex
       POSTGRES_PASSWORD: codex
     ports:
-      - "5432:5432"
+      - "${DB_PORT:-5432}:5432"
   backend:
     build: ./backend
     depends_on:
       - db
     environment:
-      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/codex
+      DB_HOST: ${DB_HOST:-db}
+      DB_PORT: ${DB_PORT:-5432}
+      SERVER_PORT: ${BACKEND_PORT:-8080}
+      FRONTEND_URL: ${FRONTEND_URL:-http://localhost:30080}
       SPRING_DATASOURCE_USERNAME: codex
       SPRING_DATASOURCE_PASSWORD: codex
     ports:
-      - "8080:8080"
+      - "${BACKEND_PORT:-8080}:8080"
   frontend:
     build: ./frontend
     ports:
-      - "4200:80"
+      - "${FRONTEND_PORT:-4200}:80"

--- a/jenkins/docker-compose.yml
+++ b/jenkins/docker-compose.yml
@@ -18,10 +18,6 @@ services:
       # handy to have for your pipeline scripts
       REGISTRY_URL: "host.docker.internal:5000"
       KUBECONFIG: "/var/jenkins_home/.kube/config/config"
-      DB_HOST: "codex-db"
-      DB_PORT: "5432"
-      BACKEND_PORT: "8080"
-      FRONTEND_URL: "http://localhost:30080"
     ports:
       - "8080:8080"
       - "50000:50000"

--- a/jenkins/docker-compose.yml
+++ b/jenkins/docker-compose.yml
@@ -18,6 +18,10 @@ services:
       # handy to have for your pipeline scripts
       REGISTRY_URL: "host.docker.internal:5000"
       KUBECONFIG: "/var/jenkins_home/.kube/config/config"
+      DB_HOST: "codex-db"
+      DB_PORT: "5432"
+      BACKEND_PORT: "8080"
+      FRONTEND_URL: "http://localhost:30080"
     ports:
       - "8080:8080"
       - "50000:50000"

--- a/kubernetes/dev/backend-deployment.yaml
+++ b/kubernetes/dev/backend-deployment.yaml
@@ -21,12 +21,16 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
-          env:
-            - name: DB_HOST
-              value: "codex-db"          # points to the Service name
-            - name: DB_PORT
-              value: "5432"
-            - name: DB_USER
+            env:
+              - name: DB_HOST
+                value: "codex-db"          # points to the Service name
+              - name: DB_PORT
+                value: "5432"
+              - name: SERVER_PORT
+                value: "${BACKEND_PORT}"
+              - name: FRONTEND_URL
+                value: "${FRONTEND_URL}"
+              - name: DB_USER
       # if your registry needs auth, uncomment this:
       # imagePullSecrets:
       #   - name: regcred


### PR DESCRIPTION
## Summary
- allow customizing CORS origin via `FRONTEND_URL` env var
- make backend port configurable via `SERVER_PORT`
- allow configuring database host/port
- propagate variables through docker compose, Jenkins and k8s manifests

## Testing
- `./backend/gradlew -p backend test --no-daemon`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68497eb38760832b9d6ec7b2942f4b89