### PR TITLE
Fix Windows compose failure

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,6 +11,10 @@ FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY docker-entrypoint.sh /docker-entrypoint.sh
+# Normalize line endings and ensure the entrypoint is executable. This avoids
+# issues when the repository is cloned on Windows with CRLF line endings.
+RUN sed -i 's/\r$//' /docker-entrypoint.sh \
+    && chmod +x /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- handle Windows line endings for `frontend/docker-entrypoint.sh`

## Testing
- `./backend/gradlew tasks`
- `npm run build` *(fails: webpack not found)*
- `docker-compose build frontend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68499db07ff8832b9f46a377ca56cc45