### PR TITLE
Fix Jenkins agent envsubst

### DIFF
--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -2,7 +2,7 @@ FROM jenkins/jenkins:lts
 
 USER root
 RUN apt-get update \
- && apt-get install -y docker.io \
+ && apt-get install -y docker.io gettext-base \
  && rm -rf /var/lib/apt/lists/* \
  && groupadd -g 999 docker  || true \
  && usermod -aG docker jenkins


### PR DESCRIPTION
## Summary
- install `gettext-base` to get `envsubst` in Jenkins image

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6849b46c856c832b9fb0dc61ca3ecc7e