### PR TITLE
Add generic ApiService for backend calls

### DIFF
--- a/frontend/src/app.component.ts
+++ b/frontend/src/app.component.ts
@@ -1,7 +1,5 @@
 import { Component } from '@angular/core';
-
-export interface Privilege { id: number; name: string; }
-export interface User { id: number; username: string; privileges: Privilege[]; }
+import { User } from './models/user';
 
 import { AuthService } from './auth.service';
 import { Router } from '@angular/router';

--- a/frontend/src/app.module.ts
+++ b/frontend/src/app.module.ts
@@ -16,6 +16,7 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatCardModule } from '@angular/material/card';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatSelectModule } from '@angular/material/select';
+import { HttpClientModule } from '@angular/common/http';
 
 import { TranslatePipe } from './i18n/translate.pipe';
 
@@ -69,7 +70,8 @@ const routes: Routes = [
     MatCheckboxModule,
     MatCardModule,
     MatSlideToggleModule,
-    MatSelectModule
+    MatSelectModule,
+    HttpClientModule
   ],
   bootstrap: [AppComponent]
 })

--- a/frontend/src/auth.service.ts
+++ b/frontend/src/auth.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@angular/core';
-import { User } from './app.component';
+import { HttpClient } from '@angular/common/http';
+import { User } from './models/user';
+import { UserService } from './services/user.service';
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
@@ -7,13 +9,11 @@ export class AuthService {
   credentials = '';
   API_URL = (window as any).API_URL || 'http://localhost:8081';
 
-  constructor() {
+  constructor(private http: HttpClient, private userService: UserService) {
     const creds = localStorage.getItem('credentials');
     if (creds) {
       this.credentials = creds;
-      fetch(`${this.API_URL}/api/users/me`, { headers: this.authHeaders() })
-        .then(r => r.ok ? r.json() : undefined)
-        .then(u => this.user = u);
+      this.userService.getCurrent().subscribe(u => this.user = u, () => {});
     }
   }
 

--- a/frontend/src/login.component.ts
+++ b/frontend/src/login.component.ts
@@ -1,7 +1,8 @@
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 import { AuthService } from './auth.service';
-import { User } from './app.component';
+import { User } from './models/user';
+import { UserService } from './services/user.service';
 
 @Component({
   selector: 'app-login',
@@ -35,24 +36,25 @@ export class LoginComponent {
   username = '';
   password = '';
 
-  constructor(private auth: AuthService, private router: Router) {}
+  constructor(
+    private auth: AuthService,
+    private router: Router,
+    private userService: UserService
+  ) {}
 
   login() {
     this.auth.credentials = btoa(`${this.username}:${this.password}`);
     localStorage.setItem('credentials', this.auth.credentials);
-    fetch(`${this.auth.API_URL}/api/users/me`, { headers: { 'Authorization': 'Basic ' + this.auth.credentials } })
-      .then(res => {
-        if (!res.ok) throw new Error('login failed');
-        return res.json();
-      })
-      .then((u: User) => {
+    this.userService.getCurrent().subscribe({
+      next: (u: User) => {
         this.auth.user = u;
         localStorage.setItem('user', JSON.stringify(u));
         this.router.navigate(['/dashboard']);
-      })
-      .catch(() => {
+      },
+      error: () => {
         localStorage.removeItem('credentials');
         alert('Login failed');
-      });
+      }
+    });
   }
 }

--- a/frontend/src/models/privilege.ts
+++ b/frontend/src/models/privilege.ts
@@ -1,0 +1,4 @@
+export interface Privilege {
+  id: number;
+  name: string;
+}

--- a/frontend/src/models/user.ts
+++ b/frontend/src/models/user.ts
@@ -1,0 +1,7 @@
+import { Privilege } from './privilege';
+
+export interface User {
+  id: number;
+  username: string;
+  privileges: Privilege[];
+}

--- a/frontend/src/navbar.component.ts
+++ b/frontend/src/navbar.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { User } from './app.component';
+import { User } from './models/user';
 
 @Component({
   selector: 'app-navbar',

--- a/frontend/src/register.component.ts
+++ b/frontend/src/register.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 import { AuthService } from './auth.service';
+import { UserService } from './services/user.service';
 
 @Component({
   selector: 'app-register',
@@ -34,15 +35,10 @@ export class RegisterComponent {
   username = '';
   password = '';
 
-  constructor(private auth: AuthService, private router: Router) {}
+  constructor(private auth: AuthService, private router: Router, private userService: UserService) {}
 
   register() {
-    const body = `username=${encodeURIComponent(this.username)}&password=${encodeURIComponent(this.password)}`;
-    fetch(`${this.auth.API_URL}/api/users/register`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body
-    }).then(() => {
+    this.userService.register(this.username, this.password).subscribe(() => {
       alert('Registered');
       this.router.navigate(['/login']);
     });

--- a/frontend/src/services/api.service.ts
+++ b/frontend/src/services/api.service.ts
@@ -1,0 +1,45 @@
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { AuthService } from '../auth.service';
+
+/**
+ * Generic service providing CRUD operations against the backend.
+ * Child services specify the resource path and model type.
+ */
+export class ApiService<T> {
+  constructor(
+    protected http: HttpClient,
+    protected auth: AuthService,
+    private resource: string
+  ) {}
+
+  list(): Observable<T[]> {
+    return this.http.get<T[]>(`${this.auth.API_URL}/${this.resource}`, {
+      headers: this.auth.authHeaders()
+    });
+  }
+
+  get(id: number): Observable<T> {
+    return this.http.get<T>(`${this.auth.API_URL}/${this.resource}/${id}`, {
+      headers: this.auth.authHeaders()
+    });
+  }
+
+  create(body: Partial<T>): Observable<T> {
+    return this.http.post<T>(`${this.auth.API_URL}/${this.resource}`, body, {
+      headers: this.auth.authHeaders()
+    });
+  }
+
+  update(id: number, body: Partial<T>): Observable<T> {
+    return this.http.put<T>(`${this.auth.API_URL}/${this.resource}/${id}`, body, {
+      headers: this.auth.authHeaders()
+    });
+  }
+
+  delete(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.auth.API_URL}/${this.resource}/${id}`, {
+      headers: this.auth.authHeaders()
+    });
+  }
+}

--- a/frontend/src/services/privilege.service.ts
+++ b/frontend/src/services/privilege.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { AuthService } from '../auth.service';
+import { Privilege } from '../models/privilege';
+import { ApiService } from './api.service';
+
+@Injectable({ providedIn: 'root' })
+export class PrivilegeService extends ApiService<Privilege> {
+  constructor(http: HttpClient, auth: AuthService) {
+    super(http, auth, 'api/privileges');
+  }
+}

--- a/frontend/src/services/user.service.ts
+++ b/frontend/src/services/user.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { AuthService } from '../auth.service';
+import { User } from '../models/user';
+import { Privilege } from '../models/privilege';
+import { ApiService } from './api.service';
+
+@Injectable({ providedIn: 'root' })
+export class UserService extends ApiService<User> {
+  constructor(http: HttpClient, auth: AuthService) {
+    super(http, auth, 'api/users');
+  }
+
+  /** Get the currently authenticated user. */
+  getCurrent(): Observable<User> {
+    return this.http.get<User>(`${this.auth.API_URL}/api/users/me`, {
+      headers: this.auth.authHeaders()
+    });
+  }
+
+  register(username: string, password: string): Observable<void> {
+    const body = `username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`;
+    return this.http.post<void>(`${this.auth.API_URL}/api/users/register`, body, {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+    });
+  }
+
+  updatePrivileges(userId: number, privileges: Privilege[] | number[]): Observable<void> {
+    const ids = privileges.map(p => typeof p === 'number' ? p : p.id);
+    return this.http.post<void>(`${this.auth.API_URL}/api/users/${userId}/privileges`, ids, {
+      headers: this.auth.authHeaders()
+    });
+  }
+}

--- a/frontend/src/top-menu.component.ts
+++ b/frontend/src/top-menu.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { User } from './app.component';
+import { User } from './models/user';
 import { TranslationService, Lang } from './i18n/translation.service';
 
 @Component({

--- a/frontend/src/users.component.ts
+++ b/frontend/src/users.component.ts
@@ -3,7 +3,8 @@ import { Router } from '@angular/router';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { AuthService } from './auth.service';
-import { User } from './app.component';
+import { UserService } from './services/user.service';
+import { User } from './models/user';
 
 @Component({
   selector: 'app-users',
@@ -41,7 +42,7 @@ export class UsersComponent implements OnInit, AfterViewInit {
   dataSource = new MatTableDataSource<User>([]);
   @ViewChild(MatPaginator) paginator?: MatPaginator;
 
-  constructor(private auth: AuthService, private router: Router) {}
+  constructor(private auth: AuthService, private router: Router, private userService: UserService) {}
 
   ngOnInit() {
     this.loadUsers();
@@ -53,14 +54,8 @@ export class UsersComponent implements OnInit, AfterViewInit {
     }
   }
 
-  private authHeaders() {
-    return this.auth.authHeaders();
-  }
-
   loadUsers() {
-    fetch(`${this.auth.API_URL}/api/users`, { headers: this.authHeaders() })
-      .then(r => r.json())
-      .then((d: User[]) => this.dataSource.data = d);
+    this.userService.list().subscribe(d => this.dataSource.data = d);
   }
 
   editUser(id: number) {
@@ -68,9 +63,6 @@ export class UsersComponent implements OnInit, AfterViewInit {
   }
 
   deleteUser(id: number) {
-    fetch(`${this.auth.API_URL}/api/users/${id}`, {
-      method: 'DELETE',
-      headers: this.authHeaders()
-    }).then(() => this.loadUsers());
+    this.userService.delete(id).subscribe(() => this.loadUsers());
   }
 }


### PR DESCRIPTION
## Summary
- create generic `ApiService` handling CRUD operations
- refactor `UserService` and `PrivilegeService` to extend the new base service
- update `AuthService` and `LoginComponent` to use `UserService`
- add `getCurrent` helper in `UserService`

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_684dfa8fb540832bb33dee4112df5373