### PR TITLE
Add numpad-controlled calculator

### DIFF
--- a/frontend/src/app.component.ts
+++ b/frontend/src/app.component.ts
@@ -11,8 +11,10 @@ import { Router } from '@angular/router';
   template: `
     <app-top-menu [user]="auth.user" (logout)="logout()"></app-top-menu>
     <mat-sidenav-container *ngIf="auth.user" class="layout">
-      <mat-sidenav mode="side" opened>
+      <mat-sidenav mode="side" opened class="sidenav">
         <app-navbar [user]="auth.user"></app-navbar>
+        <span class="spacer"></span>
+        <app-calculator></app-calculator>
       </mat-sidenav>
       <mat-sidenav-content class="content">
         <router-outlet></router-outlet>
@@ -24,6 +26,8 @@ import { Router } from '@angular/router';
   `,
   styles: [`
     .layout { height: calc(100vh - 64px); }
+    .sidenav { display: flex; flex-direction: column; height: 100%; }
+    .spacer { flex: 1 1 auto; }
   `]
 })
 export class AppComponent {

--- a/frontend/src/app.module.ts
+++ b/frontend/src/app.module.ts
@@ -28,6 +28,7 @@ import { UserEditComponent } from './user-edit.component';
 import { LoginComponent } from './login.component';
 import { RegisterComponent } from './register.component';
 import { CostSplitComponent } from './cost-split.component';
+import { CalculatorComponent } from './calculator.component';
 
 const routes: Routes = [
   { path: 'login', component: LoginComponent },
@@ -50,6 +51,7 @@ const routes: Routes = [
     LoginComponent,
     RegisterComponent,
     CostSplitComponent,
+    CalculatorComponent,
     TranslatePipe
   ],
   imports: [

--- a/frontend/src/calculator.component.ts
+++ b/frontend/src/calculator.component.ts
@@ -32,8 +32,13 @@ import { Component, HostListener } from '@angular/core';
           <button mat-button (click)="copy()">{{ 'COPY' | t }}</button>
         </div>
       </div>
-      <button mat-button class="toggle" (click)="toggleKeyboard()">
-        {{ showKeyboard ? ('HIDE_KEYS' | t) : ('SHOW_KEYS' | t) }}
+      <button
+        mat-icon-button
+        class="toggle"
+        (click)="toggleKeyboard()"
+        [attr.aria-label]="showKeyboard ? ('HIDE_KEYS' | t) : ('SHOW_KEYS' | t)"
+      >
+        <mat-icon>{{ showKeyboard ? 'expand_less' : 'expand_more' }}</mat-icon>
       </button>
     </mat-card>
   `,
@@ -41,8 +46,23 @@ import { Component, HostListener } from '@angular/core';
     .calc-card { margin: 1rem; }
     .display { font-family: monospace; text-align: right; padding: .5rem; }
     .keyboard { margin-top: .5rem; }
-    .keys { display: grid; grid-template-columns: repeat(4, 1fr); gap: .25rem; }
-    .actions { display: grid; grid-template-columns: repeat(2, 1fr); gap: .25rem; margin-top: .5rem; border-top: 1px solid rgba(0,0,0,.12); padding-top: .5rem; }
+    .keys {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: .25rem;
+    }
+    .keys button,
+    .actions button {
+      border: 1px solid rgba(0, 0, 0, .12);
+    }
+    .actions {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: .25rem;
+      margin-top: .5rem;
+      border-top: 1px solid rgba(0,0,0,.12);
+      padding-top: .5rem;
+    }
     .toggle { margin-top: .5rem; }
   `]
 })

--- a/frontend/src/calculator.component.ts
+++ b/frontend/src/calculator.component.ts
@@ -6,39 +6,43 @@ import { Component, HostListener } from '@angular/core';
     <mat-card class="calc-card">
       <div class="display">{{ display }}</div>
       <div class="keyboard" *ngIf="showKeyboard">
-        <button mat-button (click)="append('7')">7</button>
-        <button mat-button (click)="append('8')">8</button>
-        <button mat-button (click)="append('9')">9</button>
-        <button mat-button (click)="append('/')">/</button>
+        <div class="keys">
+          <button mat-button (click)="append('7')">7</button>
+          <button mat-button (click)="append('8')">8</button>
+          <button mat-button (click)="append('9')">9</button>
+          <button mat-button (click)="append('/')">/</button>
 
-        <button mat-button (click)="append('4')">4</button>
-        <button mat-button (click)="append('5')">5</button>
-        <button mat-button (click)="append('6')">6</button>
-        <button mat-button (click)="append('*')">*</button>
+          <button mat-button (click)="append('4')">4</button>
+          <button mat-button (click)="append('5')">5</button>
+          <button mat-button (click)="append('6')">6</button>
+          <button mat-button (click)="append('*')">*</button>
 
-        <button mat-button (click)="append('1')">1</button>
-        <button mat-button (click)="append('2')">2</button>
-        <button mat-button (click)="append('3')">3</button>
-        <button mat-button (click)="append('-')">-</button>
+          <button mat-button (click)="append('1')">1</button>
+          <button mat-button (click)="append('2')">2</button>
+          <button mat-button (click)="append('3')">3</button>
+          <button mat-button (click)="append('-')">-</button>
 
-        <button mat-button (click)="append('0')">0</button>
-        <button mat-button (click)="append('.')">.</button>
-        <button mat-button color="primary" (click)="evaluate()">=</button>
-        <button mat-button (click)="append('+')">+</button>
-
-        <button mat-button color="warn" class="wide" (click)="clear()">C</button>
-        <button mat-button class="wide" (click)="copy()">Copy</button>
+          <button mat-button (click)="append('0')">0</button>
+          <button mat-button (click)="append('.')">.</button>
+          <button mat-button color="primary" (click)="evaluate()">=</button>
+          <button mat-button (click)="append('+')">+</button>
+        </div>
+        <div class="actions">
+          <button mat-button color="warn" (click)="clear()">{{ 'CLEAR' | t }}</button>
+          <button mat-button (click)="copy()">{{ 'COPY' | t }}</button>
+        </div>
       </div>
       <button mat-button class="toggle" (click)="toggleKeyboard()">
-        {{ showKeyboard ? 'Hide' : 'Show' }} Keys
+        {{ showKeyboard ? ('HIDE_KEYS' | t) : ('SHOW_KEYS' | t) }}
       </button>
     </mat-card>
   `,
   styles: [`
     .calc-card { margin: 1rem; }
     .display { font-family: monospace; text-align: right; padding: .5rem; }
-    .keyboard { display: grid; grid-template-columns: repeat(4, 1fr); gap: .25rem; margin-top: .5rem; }
-    .wide { grid-column: span 2; }
+    .keyboard { margin-top: .5rem; }
+    .keys { display: grid; grid-template-columns: repeat(4, 1fr); gap: .25rem; }
+    .actions { display: grid; grid-template-columns: repeat(2, 1fr); gap: .25rem; margin-top: .5rem; border-top: 1px solid rgba(0,0,0,.12); padding-top: .5rem; }
     .toggle { margin-top: .5rem; }
   `]
 })

--- a/frontend/src/calculator.component.ts
+++ b/frontend/src/calculator.component.ts
@@ -5,16 +5,47 @@ import { Component, HostListener } from '@angular/core';
   template: `
     <mat-card class="calc-card">
       <div class="display">{{ display }}</div>
+      <div class="keyboard" *ngIf="showKeyboard">
+        <button mat-button (click)="append('7')">7</button>
+        <button mat-button (click)="append('8')">8</button>
+        <button mat-button (click)="append('9')">9</button>
+        <button mat-button (click)="append('/')">/</button>
+
+        <button mat-button (click)="append('4')">4</button>
+        <button mat-button (click)="append('5')">5</button>
+        <button mat-button (click)="append('6')">6</button>
+        <button mat-button (click)="append('*')">*</button>
+
+        <button mat-button (click)="append('1')">1</button>
+        <button mat-button (click)="append('2')">2</button>
+        <button mat-button (click)="append('3')">3</button>
+        <button mat-button (click)="append('-')">-</button>
+
+        <button mat-button (click)="append('0')">0</button>
+        <button mat-button (click)="append('.')">.</button>
+        <button mat-button color="primary" (click)="evaluate()">=</button>
+        <button mat-button (click)="append('+')">+</button>
+
+        <button mat-button color="warn" class="wide" (click)="clear()">C</button>
+        <button mat-button class="wide" (click)="copy()">Copy</button>
+      </div>
+      <button mat-button class="toggle" (click)="toggleKeyboard()">
+        {{ showKeyboard ? 'Hide' : 'Show' }} Keys
+      </button>
     </mat-card>
   `,
   styles: [`
     .calc-card { margin: 1rem; }
     .display { font-family: monospace; text-align: right; padding: .5rem; }
+    .keyboard { display: grid; grid-template-columns: repeat(4, 1fr); gap: .25rem; margin-top: .5rem; }
+    .wide { grid-column: span 2; }
+    .toggle { margin-top: .5rem; }
   `]
 })
 export class CalculatorComponent {
   display = '0';
   private expr = '';
+  showKeyboard = false;
 
   @HostListener('window:keydown', ['$event'])
   handleKey(event: KeyboardEvent) {
@@ -35,7 +66,7 @@ export class CalculatorComponent {
       this.append('/');
     } else if (code === 'NumpadEnter' || code === 'Enter') {
       this.evaluate();
-    } else if (code === 'Escape') {
+    } else if (code === 'Escape' || code === 'Delete') {
       this.clear();
     }
   }
@@ -60,5 +91,15 @@ export class CalculatorComponent {
   private clear() {
     this.expr = '';
     this.display = '0';
+  }
+
+  toggleKeyboard() {
+    this.showKeyboard = !this.showKeyboard;
+  }
+
+  copy() {
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(this.display).catch(() => {});
+    }
   }
 }

--- a/frontend/src/calculator.component.ts
+++ b/frontend/src/calculator.component.ts
@@ -1,0 +1,64 @@
+import { Component, HostListener } from '@angular/core';
+
+@Component({
+  selector: 'app-calculator',
+  template: `
+    <mat-card class="calc-card">
+      <div class="display">{{ display }}</div>
+    </mat-card>
+  `,
+  styles: [`
+    .calc-card { margin: 1rem; }
+    .display { font-family: monospace; text-align: right; padding: .5rem; }
+  `]
+})
+export class CalculatorComponent {
+  display = '0';
+  private expr = '';
+
+  @HostListener('window:keydown', ['$event'])
+  handleKey(event: KeyboardEvent) {
+    const target = event.target as HTMLElement;
+    if (target && ['INPUT', 'TEXTAREA'].includes(target.tagName)) return;
+    const code = event.code;
+    if (/^Numpad[0-9]$/.test(code)) {
+      this.append(code.slice(-1));
+    } else if (code === 'NumpadDecimal') {
+      this.append('.');
+    } else if (code === 'NumpadAdd') {
+      this.append('+');
+    } else if (code === 'NumpadSubtract') {
+      this.append('-');
+    } else if (code === 'NumpadMultiply') {
+      this.append('*');
+    } else if (code === 'NumpadDivide') {
+      this.append('/');
+    } else if (code === 'NumpadEnter' || code === 'Enter') {
+      this.evaluate();
+    } else if (code === 'Escape') {
+      this.clear();
+    }
+  }
+
+  private append(ch: string) {
+    this.expr += ch;
+    this.display = this.expr;
+  }
+
+  private evaluate() {
+    try {
+      // eslint-disable-next-line no-eval
+      const result = eval(this.expr);
+      this.display = String(result);
+      this.expr = this.display;
+    } catch {
+      this.display = 'Err';
+      this.expr = '';
+    }
+  }
+
+  private clear() {
+    this.expr = '';
+    this.display = '0';
+  }
+}

--- a/frontend/src/calculator.component.ts
+++ b/frontend/src/calculator.component.ts
@@ -4,7 +4,17 @@ import { Component, HostListener } from '@angular/core';
   selector: 'app-calculator',
   template: `
     <mat-card class="calc-card">
-      <div class="display">{{ display }}</div>
+      <div class="header">
+        <button
+          mat-icon-button
+          class="toggle"
+          (click)="toggleKeyboard()"
+          [attr.aria-label]="showKeyboard ? ('HIDE_KEYS' | t) : ('SHOW_KEYS' | t)"
+        >
+          <mat-icon>{{ showKeyboard ? 'expand_less' : 'expand_more' }}</mat-icon>
+        </button>
+        <div class="display">{{ display }}</div>
+      </div>
       <div class="keyboard" *ngIf="showKeyboard">
         <div class="keys">
           <button mat-button (click)="append('7')">7</button>
@@ -32,19 +42,12 @@ import { Component, HostListener } from '@angular/core';
           <button mat-button (click)="copy()">{{ 'COPY' | t }}</button>
         </div>
       </div>
-      <button
-        mat-icon-button
-        class="toggle"
-        (click)="toggleKeyboard()"
-        [attr.aria-label]="showKeyboard ? ('HIDE_KEYS' | t) : ('SHOW_KEYS' | t)"
-      >
-        <mat-icon>{{ showKeyboard ? 'expand_less' : 'expand_more' }}</mat-icon>
-      </button>
     </mat-card>
   `,
   styles: [`
     .calc-card { margin: 1rem; }
-    .display { font-family: monospace; text-align: right; padding: .5rem; }
+    .header { display: flex; align-items: center; }
+    .display { flex: 1; font-family: monospace; text-align: right; padding: .5rem; }
     .keyboard { margin-top: .5rem; }
     .keys {
       display: grid;
@@ -63,7 +66,7 @@ import { Component, HostListener } from '@angular/core';
       border-top: 1px solid rgba(0,0,0,.12);
       padding-top: .5rem;
     }
-    .toggle { margin-top: .5rem; }
+    .toggle { margin-right: .25rem; }
   `]
 })
 export class CalculatorComponent {

--- a/frontend/src/i18n/translations.ts
+++ b/frontend/src/i18n/translations.ts
@@ -28,6 +28,10 @@ export const translations = {
     CURRENT_YEAR_AMOUNT: 'Current year amount',
     NEXT_YEAR_AMOUNT: 'Next year amount',
     EXPORT_EXCEL: 'Export to Excel',
+    COPY: 'Copy',
+    CLEAR: 'Clear',
+    SHOW_KEYS: 'Show Keys',
+    HIDE_KEYS: 'Hide Keys',
   },
   hu: {
     LOGIN: 'Bejelentkezés',
@@ -58,5 +62,9 @@ export const translations = {
     CURRENT_YEAR_AMOUNT: 'Tárgyévi összeg',
     NEXT_YEAR_AMOUNT: 'Következő évi összeg',
     EXPORT_EXCEL: 'Excel export',
+    COPY: 'Másolás',
+    CLEAR: 'Törlés',
+    SHOW_KEYS: 'Billentyűzet megjelenítése',
+    HIDE_KEYS: 'Billentyűzet elrejtése',
   }
 } as const;


### PR DESCRIPTION
## Summary
- add `CalculatorComponent`
- show the calculator at the bottom of the sidenav
- wire up keyboard numpad controls

## Testing
- `npm run build` in `frontend`
- `./gradlew test --no-daemon` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68504955de18832b9b623bc811bbfeb5