### PR TITLE
Add EU VAT validation feature

### DIFF
--- a/backend/src/main/kotlin/com/example/codex/controller/VatController.kt
+++ b/backend/src/main/kotlin/com/example/codex/controller/VatController.kt
@@ -1,0 +1,16 @@
+package com.example.codex.controller
+
+import com.example.codex.domain.VatCheckResult
+import com.example.codex.service.VatService
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/vat")
+@CrossOrigin(origins = ["*"])
+class VatController(private val vatService: VatService) {
+
+    @GetMapping("/check")
+    fun check(@RequestParam countryCode: String, @RequestParam vatNumber: String): VatCheckResult {
+        return vatService.check(countryCode, vatNumber)
+    }
+}

--- a/backend/src/main/kotlin/com/example/codex/domain/VatCheckResult.kt
+++ b/backend/src/main/kotlin/com/example/codex/domain/VatCheckResult.kt
@@ -1,0 +1,7 @@
+package com.example.codex.domain
+
+data class VatCheckResult(
+    val valid: Boolean,
+    val name: String?,
+    val address: String?
+)

--- a/backend/src/main/kotlin/com/example/codex/service/VatService.kt
+++ b/backend/src/main/kotlin/com/example/codex/service/VatService.kt
@@ -1,0 +1,40 @@
+package com.example.codex.service
+
+import com.example.codex.domain.VatCheckResult
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestTemplate
+import java.io.StringReader
+import javax.xml.parsers.DocumentBuilderFactory
+import org.xml.sax.InputSource
+
+@Service
+class VatService {
+    private val rest = RestTemplate()
+    private val url = "https://ec.europa.eu/taxation_customs/vies/services/checkVatService"
+
+    fun check(countryCode: String, vatNumber: String): VatCheckResult {
+        val body = """
+            <soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:tns=\"urn:ec.europa.eu:taxud:vies:services:checkVat:types\">
+               <soapenv:Header/>
+               <soapenv:Body>
+                  <tns:checkVat>
+                     <tns:countryCode>${countryCode}</tns:countryCode>
+                     <tns:vatNumber>${vatNumber}</tns:vatNumber>
+                  </tns:checkVat>
+               </soapenv:Body>
+            </soapenv:Envelope>
+        """.trimIndent()
+        val headers = HttpHeaders().apply { contentType = MediaType.TEXT_XML }
+        val response = rest.postForObject(url, HttpEntity(body, headers), String::class.java)
+        val doc = DocumentBuilderFactory.newInstance().apply {
+            setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+        }.newDocumentBuilder().parse(InputSource(StringReader(response)))
+        val valid = doc.getElementsByTagName("valid").item(0).textContent.toBoolean()
+        val name = doc.getElementsByTagName("name").item(0).textContent
+        val address = doc.getElementsByTagName("address").item(0).textContent
+        return VatCheckResult(valid, name.ifBlank { null }, address.ifBlank { null })
+    }
+}

--- a/frontend/src/app.module.ts
+++ b/frontend/src/app.module.ts
@@ -28,6 +28,7 @@ import { UserEditComponent } from './user-edit.component';
 import { LoginComponent } from './login.component';
 import { RegisterComponent } from './register.component';
 import { CostSplitComponent } from './cost-split.component';
+import { VatCheckComponent } from './vat-check.component';
 
 const routes: Routes = [
   { path: 'login', component: LoginComponent },
@@ -36,6 +37,7 @@ const routes: Routes = [
   { path: 'users', component: UsersComponent },
   { path: 'users/:id', component: UserEditComponent },
   { path: 'cost-split', component: CostSplitComponent },
+  { path: 'vat-check', component: VatCheckComponent },
   { path: '', redirectTo: 'login', pathMatch: 'full' }
 ];
 
@@ -50,6 +52,7 @@ const routes: Routes = [
     LoginComponent,
     RegisterComponent,
     CostSplitComponent,
+    VatCheckComponent,
     TranslatePipe
   ],
   imports: [

--- a/frontend/src/i18n/translations.ts
+++ b/frontend/src/i18n/translations.ts
@@ -28,6 +28,12 @@ export const translations = {
     CURRENT_YEAR_AMOUNT: 'Current year amount',
     NEXT_YEAR_AMOUNT: 'Next year amount',
     EXPORT_EXCEL: 'Export to Excel',
+    VAT_CHECK: 'VAT Validator',
+    COUNTRY_CODE: 'Country code',
+    VAT_NUMBER: 'VAT number',
+    CHECK: 'Check',
+    VALID: 'Valid',
+    ADDRESS: 'Address',
   },
   hu: {
     LOGIN: 'Bejelentkezés',
@@ -58,5 +64,11 @@ export const translations = {
     CURRENT_YEAR_AMOUNT: 'Tárgyévi összeg',
     NEXT_YEAR_AMOUNT: 'Következő évi összeg',
     EXPORT_EXCEL: 'Excel export',
+    VAT_CHECK: 'EU adószám ellenőrző',
+    COUNTRY_CODE: 'Országkód',
+    VAT_NUMBER: 'Adószám',
+    CHECK: 'Ellenőrzés',
+    VALID: 'Érvényes',
+    ADDRESS: 'Cím',
   }
 } as const;

--- a/frontend/src/navbar.component.ts
+++ b/frontend/src/navbar.component.ts
@@ -8,6 +8,7 @@ import { User } from './app.component';
       <a mat-list-item routerLink="/dashboard" routerLinkActive="active" *ngIf="hasPrivilege('dashboard')">{{ 'DASHBOARD' | t }}</a>
       <a mat-list-item routerLink="/users" routerLinkActive="active" *ngIf="hasPrivilege('users')">{{ 'USERS' | t }}</a>
       <a mat-list-item routerLink="/cost-split" routerLinkActive="active">{{ 'COST_SPLIT' | t }}</a>
+      <a mat-list-item routerLink="/vat-check" routerLinkActive="active">{{ 'VAT_CHECK' | t }}</a>
     </mat-nav-list>
   `,
   styles: [`

--- a/frontend/src/vat-check.component.ts
+++ b/frontend/src/vat-check.component.ts
@@ -1,0 +1,52 @@
+import { Component } from '@angular/core';
+import { AuthService } from './auth.service';
+
+interface VatResult { valid: boolean; name?: string; address?: string; }
+
+@Component({
+  selector: 'app-vat-check',
+  template: `
+    <mat-card class="vat-card">
+      <mat-card-title>{{ 'VAT_CHECK' | t }}</mat-card-title>
+      <mat-card-content>
+        <mat-form-field appearance="fill">
+          <mat-label>{{ 'COUNTRY_CODE' | t }}</mat-label>
+          <input matInput [(ngModel)]="countryCode" placeholder="HU">
+        </mat-form-field>
+        <mat-form-field appearance="fill">
+          <mat-label>{{ 'VAT_NUMBER' | t }}</mat-label>
+          <input matInput [(ngModel)]="vatNumber" placeholder="12345676">
+        </mat-form-field>
+        <div *ngIf="result">
+          <p>{{ 'VALID' | t }}: {{ result.valid }}</p>
+          <p *ngIf="result.name">{{ 'NAME' | t }}: {{ result.name }}</p>
+          <p *ngIf="result.address">{{ 'ADDRESS' | t }}: {{ result.address }}</p>
+        </div>
+      </mat-card-content>
+      <mat-card-actions>
+        <button mat-raised-button color="primary" (click)="check()">{{ 'CHECK' | t }}</button>
+      </mat-card-actions>
+    </mat-card>
+  `,
+  styles: [`
+    .vat-card { max-width: 400px; margin: 1rem auto; display: block; }
+  `]
+})
+export class VatCheckComponent {
+  countryCode = 'HU';
+  vatNumber = '';
+  result?: VatResult;
+
+  constructor(private auth: AuthService) {}
+
+  private authHeaders() { return this.auth.authHeaders(); }
+
+  check() {
+    fetch(`${this.auth.API_URL}/api/vat/check?countryCode=${this.countryCode}&vatNumber=${this.vatNumber}`, {
+      headers: this.authHeaders()
+    })
+      .then(r => r.ok ? r.json() : Promise.reject())
+      .then((d: VatResult) => this.result = d)
+      .catch(() => alert('Error'));
+  }
+}


### PR DESCRIPTION
## Summary
- add backend VAT validation using VIES SOAP service
- expose `/api/vat/check` endpoint
- add Angular component and route for VAT checks
- extend navbar and translations

## Testing
- `./gradlew test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68554845c630832bafc9e7a2e7c42949