### PR TITLE
Add Keycloak support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,13 @@ Use Docker Compose:
 docker-compose up --build
 ```
 
-The backend will be on `http://localhost:8080` and the frontend on `http://localhost:4200`.
+The backend will be on `http://localhost:8081` and the frontend on `http://localhost:4200`.
 You can override the backend URL by setting the `API_URL` environment variable
 for the frontend container. If unspecified it defaults to `http://localhost:8081`.
+
+Keycloak is available on `http://localhost:8080` with default credentials `admin/admin`.
+The backend expects a realm called `codex`; override the issuer by setting the
+`KEYCLOAK_ISSUER_URI` environment variable.
 
 ## Managing Environments in Kubernetes
 

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-jooq")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
 
     implementation("org.jooq:jooq:3.20.0")
 

--- a/backend/src/main/kotlin/com/example/codex/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/com/example/codex/config/SecurityConfig.kt
@@ -76,7 +76,8 @@ class SecurityConfig(
                 authz
                     .requestMatchers(*AUTH_WHITELIST).permitAll()
                     .anyRequest().authenticated()
-            }.httpBasic { }
+            }.oauth2ResourceServer { it.jwt {} }
+            .httpBasic { }
         return http.build()
     }
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -5,6 +5,11 @@ spring:
     password: ${SPRING_DATASOURCE_PASSWORD}
   jooq:
     sql-dialect: POSTGRES
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${KEYCLOAK_ISSUER_URI}
 
 frontendUrl: ${FRONTEND_URL}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,16 +8,26 @@ services:
       POSTGRES_PASSWORD: codex
     ports:
       - "${DB_PORT:-5432}:5432"
+  keycloak:
+    image: quay.io/keycloak/keycloak:22.0
+    command: start-dev
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+    ports:
+      - "${KEYCLOAK_PORT:-8080}:8080"
   backend:
     build: ./backend
     depends_on:
       - db
+      - keycloak
     environment:
       DB_HOST: ${DB_HOST:-db}
       DB_PORT: ${DB_PORT:-5432}
       FRONTEND_URL: ${FRONTEND_URL:-http://localhost:4200}
       SPRING_DATASOURCE_USERNAME: codex
       SPRING_DATASOURCE_PASSWORD: codex
+      KEYCLOAK_ISSUER_URI: ${KEYCLOAK_ISSUER_URI:-http://keycloak:8080/realms/codex}
     ports:
       - "${BACKEND_PORT:-8081}:8080"
   frontend:


### PR DESCRIPTION
## Summary
- run Keycloak alongside the stack via docker-compose
- secure backend with OAuth2 resource server using Keycloak JWTs
- document Keycloak configuration and defaults

## Testing
- `./backend/gradlew -p backend test`
- `npm test --prefix frontend` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68967ce15904832b9df69cecd2ba5519