### PR TITLE
Add Skaffold config for backend dev deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,6 +56,7 @@ pipeline {
 			envsubst < kubernetes/dev/frontend-deployment.yaml | kubectl apply -f -
 			
 			# Apply the Postgres DB
+                        kubectl apply -f kubernetes/dev/db-secret.yaml
                         kubectl apply -f kubernetes/dev/db.yaml
                   '''
                 }

--- a/KUBERNETES.md
+++ b/KUBERNETES.md
@@ -64,3 +64,8 @@ skaffold run -f frontend/skaffold.yaml --default-repo host.docker.internal:5000
 ```
 
 These commands mirror the `dev` deployment performed in the Jenkins pipeline.
+
+## start kubernetes frontend
+start "" /min kubectl proxy --address=0.0.0.0 --port=8001
+kubectl -n kubernetes-dashboard create token dashboard-admin
+http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/login

--- a/KUBERNETES.md
+++ b/KUBERNETES.md
@@ -45,6 +45,16 @@ runs tests, builds the frontend and backend containers, and applies the files fo
 
 Refer to the official [Kubernetes documentation](https://kubernetes.io/docs/home/) for additional best practices.
 
+## Skaffold
+
+For a streamlined developer workflow, you can use [Skaffold](https://skaffold.dev) to build the backend image and deploy the dev environment manifests:
+
+```bash
+skaffold run -f backend/skaffold.yaml --default-repo host.docker.internal:5000
+```
+
+This mirrors the `dev` deployment performed in the Jenkins pipeline.
+
 
 
 

--- a/KUBERNETES.md
+++ b/KUBERNETES.md
@@ -47,18 +47,20 @@ Refer to the official [Kubernetes documentation](https://kubernetes.io/docs/home
 
 ## Skaffold
 
-For a streamlined developer workflow, you can use [Skaffold](https://skaffold.dev) to build the backend image and deploy the dev environment manifests:
+For a streamlined developer workflow, you can use [Skaffold](https://skaffold.dev) to build images and deploy the `dev` environment manifests.
+
+### Backend
 
 ```bash
+
 skaffold run -f backend/skaffold.yaml --default-repo host.docker.internal:5000
 ```
 
-This mirrors the `dev` deployment performed in the Jenkins pipeline.
+### Frontend
 
+```bash
 
+skaffold run -f frontend/skaffold.yaml --default-repo host.docker.internal:5000
+```
 
-
-start "" /min kubectl proxy --address=0.0.0.0 --port=8001
-kubectl -n kubernetes-dashboard create token dashboard-admin
-
-eyJhbGciOiJSUzI1NiIsImtpZCI6IjBUM2ZtZTJrU2lDREdLZERUdEppcngxekQwR3JlX003QWc1bU1tNFcyZjgifQ.eyJhdWQiOlsiaHR0cHM6Ly9rdWJlcm5ldGVzLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwiXSwiZXhwIjoxNzQ5NjExMzcwLCJpYXQiOjE3NDk2MDc3NzAsImlzcyI6Imh0dHBzOi8va3ViZXJuZXRlcy5kZWZhdWx0LnN2Yy5jbHVzdGVyLmxvY2FsIiwianRpIjoiODQyOWM1ZWUtMzQyNC00MDVmLWJhZGQtNmNiN2NlMzExMGE0Iiwia3ViZXJuZXRlcy5pbyI6eyJuYW1lc3BhY2UiOiJrdWJlcm5ldGVzLWRhc2hib2FyZCIsInNlcnZpY2VhY2NvdW50Ijp7Im5hbWUiOiJkYXNoYm9hcmQtYWRtaW4iLCJ1aWQiOiI0ODVhZmU5Mi0zNmEyLTRiMmUtYTY5Mi1lYTY1Y2RlZTMxNzMifX0sIm5iZiI6MTc0OTYwNzc3MCwic3ViIjoic3lzdGVtOnNlcnZpY2VhY2NvdW50Omt1YmVybmV0ZXMtZGFzaGJvYXJkOmRhc2hib2FyZC1hZG1pbiJ9.Ne4uZaZvd8rdw6gDNewVPI0h09L9wZv4Q14OHXDanq_LQWwzB2fvYXqXtdNFKsnkns1aWvuZ2KOdkl8tKBvE6yTRt-JF3XOQfr1bQQ66cN3kO8LXIP8gPE6v5nD8bBHDTt_74TvGz6Fa3PyJAzWWukn6i6nrmG9BZFMJaBxGQkSE28kZJPk6tjdjJSFBxrKzwaPe2OY2LtFCznT6TOCF-pbWBXSSZyeB8KtK6qOayYJ4dGbj6tBSqcjbWJQT6_cNMxQOyYFSrLFpV1QN0_1YtwlVBfug8x9ofItWjC6tgCL4ZDcqfgBfQ6N8gg7wKX_MOw2T5Ii_mfQAD7aYdIItBw
+These commands mirror the `dev` deployment performed in the Jenkins pipeline.

--- a/README.md
+++ b/README.md
@@ -27,15 +27,21 @@ for the frontend container. If unspecified it defaults to `http://localhost:8081
 
 For deployments beyond local development, you can manage separate environments (development, staging, production) using Kubernetes. See [KUBERNETES.md](KUBERNETES.md) for a basic overview and example structure. A sample Jenkins pipeline is provided in the [Jenkinsfile](Jenkinsfile) to automate builds and deployments.
 
-### Deploying the backend with Skaffold
+### Deploying with Skaffold
 
-To build and deploy the backend to the `dev` namespace, a [Skaffold](https://skaffold.dev) configuration is available at `backend/skaffold.yaml`. With a Kubernetes cluster and registry reachable from your environment you can run:
+To build and deploy the backend to the `dev` namespace:
 
 ```bash
 skaffold run -f backend/skaffold.yaml --default-repo host.docker.internal:5000
 ```
 
-This command builds the backend image, pushes it to the registry and applies the manifests in `kubernetes/dev` to create the namespace, database and backend deployment.
+To build and deploy the frontend to the `dev` namespace:
+
+```bash
+skaffold run -f frontend/skaffold.yaml --default-repo host.docker.internal:5000
+```
+
+Each command builds the corresponding image, pushes it to the registry and applies the manifests in `kubernetes/dev`.
 
 ## Jenkins Build Environment
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ for the frontend container. If unspecified it defaults to `http://localhost:8081
 
 For deployments beyond local development, you can manage separate environments (development, staging, production) using Kubernetes. See [KUBERNETES.md](KUBERNETES.md) for a basic overview and example structure. A sample Jenkins pipeline is provided in the [Jenkinsfile](Jenkinsfile) to automate builds and deployments.
 
+### Deploying the backend with Skaffold
+
+To build and deploy the backend to the `dev` namespace, a [Skaffold](https://skaffold.dev) configuration is available at `backend/skaffold.yaml`. With a Kubernetes cluster and registry reachable from your environment you can run:
+
+```bash
+skaffold run -f backend/skaffold.yaml --default-repo host.docker.internal:5000
+```
+
+This command builds the backend image, pushes it to the registry and applies the manifests in `kubernetes/dev` to create the namespace, database and backend deployment.
+
 ## Jenkins Build Environment
 
 A Dockerfile is provided under `jenkins/` to build a Jenkins agent image with Node.js, the Docker CLI and `kubectl` installed. Build it with:

--- a/backend/skaffold.yaml
+++ b/backend/skaffold.yaml
@@ -1,0 +1,16 @@
+apiVersion: skaffold/v4beta1
+kind: Config
+metadata:
+  name: codex-backend
+build:
+  artifacts:
+    - image: codex-backend
+      context: .
+      docker:
+        dockerfile: Dockerfile
+deploy:
+  kubectl:
+    manifests:
+      - ../kubernetes/dev/namespace.yaml
+      - ../kubernetes/dev/db.yaml
+      - ../kubernetes/dev/backend-skaffold.yaml

--- a/backend/skaffold.yaml
+++ b/backend/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta1
+apiVersion: skaffold/v2alpha3
 kind: Config
 metadata:
   name: codex-backend
@@ -8,9 +8,12 @@ build:
       context: .
       docker:
         dockerfile: Dockerfile
+  local:
+    push: true
 deploy:
   kubectl:
     manifests:
       - ../kubernetes/dev/namespace.yaml
       - ../kubernetes/dev/db.yaml
+      - ../kubernetes/dev/db-secret.yaml
       - ../kubernetes/dev/backend-skaffold.yaml

--- a/frontend/skaffold.yaml
+++ b/frontend/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta1
+apiVersion: skaffold/v2alpha3
 kind: Config
 metadata:
   name: codex-frontend
@@ -8,6 +8,8 @@ build:
       context: .
       docker:
         dockerfile: Dockerfile
+  local:
+    push: true
 deploy:
   kubectl:
     manifests:

--- a/frontend/skaffold.yaml
+++ b/frontend/skaffold.yaml
@@ -1,0 +1,15 @@
+apiVersion: skaffold/v4beta1
+kind: Config
+metadata:
+  name: codex-frontend
+build:
+  artifacts:
+    - image: codex-frontend
+      context: .
+      docker:
+        dockerfile: Dockerfile
+deploy:
+  kubectl:
+    manifests:
+      - ../kubernetes/dev/namespace.yaml
+      - ../kubernetes/dev/frontend-skaffold.yaml

--- a/kubernetes/dev/backend-skaffold.yaml
+++ b/kubernetes/dev/backend-skaffold.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: dev
+  name: codex-backend
+  labels:
+    app: codex-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: codex-backend
+  template:
+    metadata:
+      labels:
+        app: codex-backend
+    spec:
+      containers:
+        - name: backend
+          # image built by Skaffold
+          image: codex-backend
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+          env:
+            - name: DB_HOST
+              value: "codex-db"          # points to the Service name
+            - name: DB_PORT
+              value: "5432"
+            - name: FRONTEND_URL
+              value: "http://localhost:30080"
+            - name: SPRING_DATASOURCE_USERNAME
+              value: codex
+            - name: SPRING_DATASOURCE_PASSWORD
+              value: codex
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: codex-backend
+  namespace: dev
+  labels:
+    app: codex-backend
+spec:
+  type: NodePort
+  selector:
+    app: codex-backend
+  ports:
+    - port: 80
+      targetPort: 8080
+      nodePort: 30081

--- a/kubernetes/dev/db-secret.yaml
+++ b/kubernetes/dev/db-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+metadata:
+  namespace: dev
+  name: codex-db-credentials
+  labels:
+    app: codex-db
+type: Opaque
+kind: Secret
+stringData:
+  POSTGRES_DB: codex
+  POSTGRES_USER: codex
+  POSTGRES_PASSWORD: codex

--- a/kubernetes/dev/db.yaml
+++ b/kubernetes/dev/db.yaml
@@ -1,19 +1,5 @@
 ---
 apiVersion: v1
-kind: Secret
-metadata:
-  namespace: dev
-  name: codex-db-credentials
-  labels:
-    app: codex-db
-type: Opaque
-stringData:
-  POSTGRES_DB: codex
-  POSTGRES_USER: codex
-  POSTGRES_PASSWORD: codex
-
----
-apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   namespace: dev

--- a/kubernetes/dev/frontend-skaffold.yaml
+++ b/kubernetes/dev/frontend-skaffold.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: dev
+  name: codex-frontend
+  labels:
+    app: codex-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: codex-frontend
+  template:
+    metadata:
+      labels:
+        app: codex-frontend
+    spec:
+      containers:
+        - name: frontend
+          # image built by Skaffold
+          image: codex-frontend
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 80
+          env:
+            - name: API_URL
+              value: "http://localhost:30081"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: codex-frontend
+  namespace: dev
+  labels:
+    app: codex-frontend
+spec:
+  type: NodePort
+  selector:
+    app: codex-frontend
+  ports:
+    - port: 80
+      targetPort: 80
+      nodePort: 30080


### PR DESCRIPTION
## Summary
- add Skaffold config to build backend image and apply dev manifests
- document Skaffold usage for dev Kubernetes deploys

## Testing
- `./gradlew test --no-daemon` *(fails: stuck downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a362f7afbc832b80287ea835115e19