### PR TITLE
feat(frontend): polish login form styling

### DIFF
--- a/frontend/src/login.component.ts
+++ b/frontend/src/login.component.ts
@@ -6,20 +6,25 @@ import { User } from './app.component';
 @Component({
   selector: 'app-login',
   template: `
-    <div class="login">
-      <mat-card>
-        <mat-card-title>{{ 'LOGIN' | t }}</mat-card-title>
+    <div class="login-container">
+      <mat-card class="login-card mat-elevation-z8">
+        <mat-card-title class="title">{{ 'LOGIN' | t }}</mat-card-title>
         <mat-card-content>
-          <mat-form-field appearance="fill">
+          <mat-form-field appearance="outline">
             <mat-label>{{ 'USERNAME' | t }}</mat-label>
+            <mat-icon matPrefix>person</mat-icon>
             <input matInput [(ngModel)]="username">
           </mat-form-field>
-          <mat-form-field appearance="fill">
+          <mat-form-field appearance="outline">
             <mat-label>{{ 'PASSWORD' | t }}</mat-label>
-            <input matInput type="password" [(ngModel)]="password">
+            <mat-icon matPrefix>lock</mat-icon>
+            <input matInput [type]="hidePassword ? 'password' : 'text'" [(ngModel)]="password">
+            <button mat-icon-button matSuffix type="button" (click)="hidePassword = !hidePassword">
+              <mat-icon>{{ hidePassword ? 'visibility_off' : 'visibility' }}</mat-icon>
+            </button>
           </mat-form-field>
         </mat-card-content>
-        <mat-card-actions>
+        <mat-card-actions class="actions">
           <button mat-raised-button color="primary" (click)="login()">{{ 'LOGIN' | t }}</button>
           <a mat-button routerLink="/register">{{ 'REGISTER' | t }}</a>
         </mat-card-actions>
@@ -27,13 +32,17 @@ import { User } from './app.component';
     </div>
   `,
   styles: [`
-    .login { height: calc(100vh - 64px); display: flex; justify-content: center; align-items: center; background: #303030; color: #fff; }
-    mat-card { width: 300px; }
+    .login-container { height: calc(100vh - 64px); display: flex; justify-content: center; align-items: center; background: linear-gradient(135deg, #1a237e, #303f9f); }
+    .login-card { width: 320px; padding: 24px; }
+    .title { text-align: center; margin-bottom: 16px; }
+    mat-form-field { width: 100%; margin-bottom: 16px; }
+    .actions { display: flex; justify-content: space-between; }
   `]
 })
 export class LoginComponent {
   username = '';
   password = '';
+  hidePassword = true;
 
   constructor(private auth: AuthService, private router: Router) {}
 


### PR DESCRIPTION
## Summary
- refine login card with elevation, spacing, and flex actions for a cleaner layout
- switch fields to outlined appearance and tweak gradient backdrop for better contrast

## Testing
- `npm --prefix frontend ci`
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8ac0515b0832b9e1e7158a5d005de