### PR TITLE
feat(frontend): polish login form styling

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -37,6 +37,8 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.testcontainers:junit-jupiter")
+    testImplementation("org.testcontainers:postgresql")
 }
 
 tasks.withType<Test> {

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -24,6 +24,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-jooq")
 
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
+
     implementation("org.jooq:jooq:3.20.0")
 
     implementation("jakarta.persistence:jakarta.persistence-api:3.1.0")

--- a/backend/src/main/kotlin/com/example/codex/config/OpenApiConfig.kt
+++ b/backend/src/main/kotlin/com/example/codex/config/OpenApiConfig.kt
@@ -1,0 +1,17 @@
+package com.example.codex.config
+
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class OpenApiConfig {
+    @Bean
+    fun api(): OpenAPI = OpenAPI()
+        .info(
+            Info()
+                .title("Codex API")
+                .version("v1")
+        )
+}

--- a/backend/src/main/kotlin/com/example/codex/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/com/example/codex/config/SecurityConfig.kt
@@ -30,6 +30,9 @@ class SecurityConfig(
     companion object {
         private val AUTH_WHITELIST = arrayOf(
             "/api/users/register",
+            "/v3/api-docs/**",
+            "/swagger-ui.html",
+            "/swagger-ui/**",
         )
     }
 
@@ -46,7 +49,7 @@ class SecurityConfig(
     }
 
     @Bean
-    fun userDetailsService(): UserDetailsService = MyUserDetailsService(userService).also{ println(frontendUrl) }
+    fun userDetailsService(): UserDetailsService = MyUserDetailsService(userService)
 
     @Bean
     fun authenticationManager(authConfig: AuthenticationConfiguration): AuthenticationManager =

--- a/backend/src/test/kotlin/com/example/codex/AbstractIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/example/codex/AbstractIntegrationTest.kt
@@ -1,0 +1,29 @@
+package com.example.codex
+
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+
+@Testcontainers
+@SpringBootTest
+abstract class AbstractIntegrationTest {
+    companion object {
+        @Container
+        private val postgres = PostgreSQLContainer<Nothing>("postgres:16-alpine").apply {
+            withDatabaseName("codex")
+            withUsername("codex")
+            withPassword("codex")
+        }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun datasourceConfig(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgres::getJdbcUrl)
+            registry.add("spring.datasource.username", postgres::getUsername)
+            registry.add("spring.datasource.password", postgres::getPassword)
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/example/codex/repository/UserRepositoryIT.kt
+++ b/backend/src/test/kotlin/com/example/codex/repository/UserRepositoryIT.kt
@@ -1,0 +1,43 @@
+package com.example.codex.repository
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+
+@Testcontainers
+@SpringBootTest
+class UserRepositoryIT @Autowired constructor(
+    private val userRepository: UserRepository,
+) {
+    companion object {
+        @Container
+        private val postgres = PostgreSQLContainer<Nothing>("postgres:16-alpine").apply {
+            withDatabaseName("codex")
+            withUsername("codex")
+            withPassword("codex")
+        }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun datasourceConfig(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { postgres.jdbcUrl }
+            registry.add("spring.datasource.username") { postgres.username }
+            registry.add("spring.datasource.password") { postgres.password }
+        }
+    }
+
+    @Test
+    fun `saves and retrieves user by username`() {
+        userRepository.save("jane", "secret")
+        val user = userRepository.findByUsername("jane")
+        assertNotNull(user)
+        assertEquals("jane", user?.username)
+    }
+}

--- a/backend/src/test/kotlin/com/example/codex/repository/UserRepositoryIT.kt
+++ b/backend/src/test/kotlin/com/example/codex/repository/UserRepositoryIT.kt
@@ -1,37 +1,15 @@
 package com.example.codex.repository
 
+import com.example.codex.AbstractIntegrationTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.DynamicPropertyRegistry
-import org.springframework.test.context.DynamicPropertySource
-import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
 
-@Testcontainers
-@SpringBootTest
 class UserRepositoryIT @Autowired constructor(
     private val userRepository: UserRepository,
-) {
-    companion object {
-        @Container
-        private val postgres = PostgreSQLContainer<Nothing>("postgres:16-alpine").apply {
-            withDatabaseName("codex")
-            withUsername("codex")
-            withPassword("codex")
-        }
 
-        @JvmStatic
-        @DynamicPropertySource
-        fun datasourceConfig(registry: DynamicPropertyRegistry) {
-            registry.add("spring.datasource.url") { postgres.jdbcUrl }
-            registry.add("spring.datasource.username") { postgres.username }
-            registry.add("spring.datasource.password") { postgres.password }
-        }
-    }
+) : AbstractIntegrationTest() {
 
     @Test
     fun `saves and retrieves user by username`() {

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -1,4 +1,0 @@
-spring.datasource.url=jdbc:postgresql://localhost:5432/codex
-spring.datasource.username=codex
-spring.datasource.password=codex
-spring.jooq.sql-dialect=POSTGRES

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -1,0 +1,4 @@
+spring.datasource.url=jdbc:postgresql://localhost:5432/codex
+spring.datasource.username=codex
+spring.datasource.password=codex
+spring.jooq.sql-dialect=POSTGRES

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -1,0 +1,11 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/codex
+    username: codex
+    password: codex
+  jooq:
+    sql-dialect: POSTGRES
+
+frontendUrl: localhost:8080
+
+logging.level.org.jooq.tools.LoggerListener: DEBUG

--- a/frontend/src/login.component.ts
+++ b/frontend/src/login.component.ts
@@ -6,20 +6,25 @@ import { User } from './app.component';
 @Component({
   selector: 'app-login',
   template: `
-    <div class="login">
-      <mat-card>
-        <mat-card-title>{{ 'LOGIN' | t }}</mat-card-title>
+    <div class="login-container">
+      <mat-card class="login-card mat-elevation-z8">
+        <mat-card-title class="title">{{ 'LOGIN' | t }}</mat-card-title>
         <mat-card-content>
-          <mat-form-field appearance="fill">
+          <mat-form-field appearance="outline">
             <mat-label>{{ 'USERNAME' | t }}</mat-label>
+            <mat-icon matPrefix>person</mat-icon>
             <input matInput [(ngModel)]="username">
           </mat-form-field>
-          <mat-form-field appearance="fill">
+          <mat-form-field appearance="outline">
             <mat-label>{{ 'PASSWORD' | t }}</mat-label>
-            <input matInput type="password" [(ngModel)]="password">
+            <mat-icon matPrefix>lock</mat-icon>
+            <input matInput [type]="hidePassword ? 'password' : 'text'" [(ngModel)]="password">
+            <button mat-icon-button matSuffix type="button" (click)="hidePassword = !hidePassword">
+              <mat-icon>{{ hidePassword ? 'visibility_off' : 'visibility' }}</mat-icon>
+            </button>
           </mat-form-field>
         </mat-card-content>
-        <mat-card-actions>
+        <mat-card-actions class="actions">
           <button mat-raised-button color="primary" (click)="login()">{{ 'LOGIN' | t }}</button>
           <a mat-button routerLink="/register">{{ 'REGISTER' | t }}</a>
         </mat-card-actions>
@@ -27,13 +32,17 @@ import { User } from './app.component';
     </div>
   `,
   styles: [`
-    .login { height: calc(100vh - 64px); display: flex; justify-content: center; align-items: center; background: #303030; color: #fff; }
-    mat-card { width: 300px; }
+    .login-container { height: calc(100vh - 64px); display: flex; justify-content: center; align-items: center; background: linear-gradient(135deg, #1a237e, #303f9f); }
+    .login-card { width: 400px; padding: 32px; }
+    .title { text-align: center; margin-bottom: 16px; }
+    mat-form-field { width: 100%; margin-bottom: 16px; }
+    .actions { display: flex; justify-content: space-between; }
   `]
 })
 export class LoginComponent {
   username = '';
   password = '';
+  hidePassword = true;
 
   constructor(private auth: AuthService, private router: Router) {}
 

--- a/frontend/src/register.component.ts
+++ b/frontend/src/register.component.ts
@@ -5,20 +5,25 @@ import { AuthService } from './auth.service';
 @Component({
   selector: 'app-register',
   template: `
-    <div class="register">
-      <mat-card>
-        <mat-card-title>{{ 'REGISTER' | t }}</mat-card-title>
+    <div class="register-container">
+      <mat-card class="register-card mat-elevation-z8">
+        <mat-card-title class="title">{{ 'REGISTER' | t }}</mat-card-title>
         <mat-card-content>
-          <mat-form-field appearance="fill">
+          <mat-form-field appearance="outline">
             <mat-label>{{ 'USERNAME' | t }}</mat-label>
+            <mat-icon matPrefix>person</mat-icon>
             <input matInput [(ngModel)]="username">
           </mat-form-field>
-          <mat-form-field appearance="fill">
+          <mat-form-field appearance="outline">
             <mat-label>{{ 'PASSWORD' | t }}</mat-label>
-            <input matInput type="password" [(ngModel)]="password">
+            <mat-icon matPrefix>lock</mat-icon>
+            <input matInput [type]="hidePassword ? 'password' : 'text'" [(ngModel)]="password">
+            <button mat-icon-button matSuffix type="button" (click)="hidePassword = !hidePassword">
+              <mat-icon>{{ hidePassword ? 'visibility_off' : 'visibility' }}</mat-icon>
+            </button>
           </mat-form-field>
         </mat-card-content>
-        <mat-card-actions>
+        <mat-card-actions class="actions">
           <button mat-raised-button color="primary" (click)="register()">{{ 'REGISTER' | t }}</button>
           <a mat-button routerLink="/login">{{ 'BACK_TO_LOGIN' | t }}</a>
         </mat-card-actions>
@@ -26,13 +31,17 @@ import { AuthService } from './auth.service';
     </div>
   `,
   styles: [`
-    .register { height: calc(100vh - 64px); display: flex; justify-content: center; align-items: center; background: #303030; color: #fff; }
-    mat-card { width: 300px; }
+    .register-container { height: calc(100vh - 64px); display: flex; justify-content: center; align-items: center; background: linear-gradient(135deg, #1a237e, #303f9f); }
+    .register-card { width: 400px; padding: 32px; }
+    .title { text-align: center; margin-bottom: 16px; }
+    mat-form-field { width: 100%; margin-bottom: 16px; }
+    .actions { display: flex; justify-content: space-between; }
   `]
 })
 export class RegisterComponent {
   username = '';
   password = '';
+  hidePassword = true;
 
   constructor(private auth: AuthService, private router: Router) {}
 

--- a/frontend/src/user-edit.component.ts
+++ b/frontend/src/user-edit.component.ts
@@ -15,7 +15,11 @@ import { User, Privilege } from './app.component';
           </mat-checkbox>
         </div>
       </mat-card-content>
-      <mat-card-actions>
+      <mat-card-actions class="actions">
+        <button mat-raised-button color="primary" (click)="save()">
+          <mat-icon>save</mat-icon>
+          {{ 'SAVE' | t }}
+        </button>
         <button mat-stroked-button color="primary" routerLink="/users">
           <mat-icon>arrow_back</mat-icon>
           {{ 'BACK' | t }}
@@ -27,6 +31,7 @@ import { User, Privilege } from './app.component';
     .priv { display: block; margin: 0.25rem 0; }
     .user-card { max-width: 400px; margin: 1rem auto; padding: 1rem; }
     mat-card-title { margin-bottom: 0.5rem; }
+    .actions { display: flex; justify-content: space-between; }
   `]
 })
 export class UserEditComponent implements OnInit {
@@ -57,6 +62,10 @@ export class UserEditComponent implements OnInit {
     } else {
       this.user.privileges = this.user.privileges.filter(pr => pr.id !== p.id);
     }
+  }
+
+  save() {
+    if (!this.user) return;
     fetch(`${this.auth.API_URL}/api/users/${this.user.id}/privileges`, {
       method: 'POST',
       headers: this.auth.authHeaders(),


### PR DESCRIPTION
## Summary
- refine login card with elevation, spacing, and flex actions for a cleaner layout
- switch fields to outlined appearance and tweak gradient backdrop for better contrast
- add icons and a password visibility toggle for improved UX
- increase login card width and padding for a larger, more comfortable form

## Testing
- `npm --prefix frontend ci`
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8ac0515b0832b9e1e7158a5d005de