### PR TITLE
Add Gradle integration test task and Jenkins job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,18 +25,8 @@ pipeline {
 
     stage('Integration Tests') {
       steps {
-        // Install and start a local Postgres instance, then run integration tests
-        sh '''
-          sudo apt-get update
-          sudo apt-get install -y postgresql
-          sudo -u postgres /usr/lib/postgresql/16/bin/pg_ctl \
-            -D /etc/postgresql/16/main \
-            -l /tmp/postgresql.log start
-          sudo -u postgres psql -c "ALTER USER postgres WITH PASSWORD 'postgres';"
-          sudo -u postgres psql -c 'CREATE DATABASE "postgresTest";'
-        '''
         dir('backend') {
-          sh 'DISABLE_TESTCONTAINERS=true ./gradlew integrationTest --no-daemon'
+          sh './gradlew integrationTest --no-daemon'
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,24 @@ pipeline {
       }
     }
 
+    stage('Integration Tests') {
+      steps {
+        // Install and start a local Postgres instance, then run integration tests
+        sh '''
+          sudo apt-get update
+          sudo apt-get install -y postgresql
+          sudo -u postgres /usr/lib/postgresql/16/bin/pg_ctl \
+            -D /etc/postgresql/16/main \
+            -l /tmp/postgresql.log start
+          sudo -u postgres psql -c "ALTER USER postgres WITH PASSWORD 'postgres';"
+          sudo -u postgres psql -c 'CREATE DATABASE "postgresTest";'
+        '''
+        dir('backend') {
+          sh 'DISABLE_TESTCONTAINERS=true ./gradlew integrationTest --no-daemon'
+        }
+      }
+    }
+
     stage('Build & Push Images') {
       steps {
         script {

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS — Backend
+
+## Testing
+- Run unit tests:
+  ```bash
+  ./gradlew test --no-daemon
+  ```
+- Run integration tests with Testcontainers (default):
+  ```bash
+  ./gradlew integrationTest --no-daemon
+  ```
+- Run integration tests against a local Postgres:
+  ```bash
+  DISABLE_TESTCONTAINERS=true ./gradlew integrationTest --no-daemon
+  ```
+  Ensure a PostgreSQL instance is available and, if necessary, set `SPRING_DATASOURCE_URL`, `SPRING_DATASOURCE_USERNAME`, and `SPRING_DATASOURCE_PASSWORD` (defaults: `jdbc:postgresql://localhost:5432/postgresTest`, `postgres`, `postgres`).

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import nu.studer.gradle.jooq.JooqEdition
 import org.jooq.meta.jaxb.Property
+import org.gradle.api.tasks.testing.Test
 plugins {
     kotlin("jvm") version "2.0.0"
     id("org.jetbrains.kotlin.plugin.spring") version "2.1.21"
@@ -43,7 +44,25 @@ dependencies {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    // exclude integration tests from the standard unit test task
+    exclude("**/*IT.*")
 }
+
+// Dedicated task for running integration tests (classes named *IT)
+val integrationTest by tasks.registering(Test::class) {
+    description = "Runs the integration tests."
+    group = "verification"
+    useJUnitPlatform()
+    testClassesDirs = sourceSets["test"].output.classesDirs
+    classpath = sourceSets["test"].runtimeClasspath
+    shouldRunAfter("test")
+    // Remove the global IT exclusion and only run classes that end with IT
+    excludes.clear()
+    include("**/*IT.*")
+    filter { includeTestsMatching("*IT") }
+}
+
+tasks.check { dependsOn(integrationTest) }
 
 jooq {
     version.set("3.20.0")

--- a/backend/src/test/kotlin/com/example/codex/AbstractIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/example/codex/AbstractIntegrationTest.kt
@@ -1,17 +1,16 @@
 package com.example.codex
 
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
 
-@Testcontainers
 @SpringBootTest
 abstract class AbstractIntegrationTest {
     companion object {
-        @Container
+        private val useTestcontainers = System.getenv("DISABLE_TESTCONTAINERS") != "true"
         private val postgres = PostgreSQLContainer<Nothing>("postgres:16-alpine").apply {
             withDatabaseName("codex")
             withUsername("codex")
@@ -19,11 +18,33 @@ abstract class AbstractIntegrationTest {
         }
 
         @JvmStatic
+        @BeforeAll
+        fun startContainer() {
+            if (useTestcontainers) {
+                postgres.start()
+            }
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun stopContainer() {
+            if (useTestcontainers) {
+                postgres.stop()
+            }
+        }
+
+        @JvmStatic
         @DynamicPropertySource
         fun datasourceConfig(registry: DynamicPropertyRegistry) {
-            registry.add("spring.datasource.url", postgres::getJdbcUrl)
-            registry.add("spring.datasource.username", postgres::getUsername)
-            registry.add("spring.datasource.password", postgres::getPassword)
+            if (useTestcontainers) {
+                registry.add("spring.datasource.url", postgres::getJdbcUrl)
+                registry.add("spring.datasource.username", postgres::getUsername)
+                registry.add("spring.datasource.password", postgres::getPassword)
+            } else {
+                registry.add("spring.datasource.url") { System.getenv("SPRING_DATASOURCE_URL") ?: "jdbc:postgresql://localhost:5432/postgresTest" }
+                registry.add("spring.datasource.username") { System.getenv("SPRING_DATASOURCE_USERNAME") ?: "postgres" }
+                registry.add("spring.datasource.password") { System.getenv("SPRING_DATASOURCE_PASSWORD") ?: "postgres" }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add dedicated `integrationTest` Gradle task and exclude ITs from default `test`
- allow integration tests to run without Testcontainers via `DISABLE_TESTCONTAINERS`
- run integration tests in Jenkins by installing Postgres and invoking `./gradlew integrationTest`

## Testing
- `./gradlew test --no-daemon`
- `DISABLE_TESTCONTAINERS=true ./gradlew integrationTest --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68a8f24a2920832bb5701a13716286de