### PR TITLE
Add integration tests for UserRepository

### DIFF
--- a/backend/src/test/kotlin/com/example/codex/repository/UserRepositoryIT.kt
+++ b/backend/src/test/kotlin/com/example/codex/repository/UserRepositoryIT.kt
@@ -3,6 +3,8 @@ package com.example.codex.repository
 import com.example.codex.AbstractIntegrationTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -17,5 +19,35 @@ class UserRepositoryIT @Autowired constructor(
         val user = userRepository.findByUsername("jane")
         assertNotNull(user)
         assertEquals("jane", user?.username)
+    }
+
+    @Test
+    fun `soft deletes user`() {
+        userRepository.save("john", "secret")
+        val id = userRepository.findByUsername("john")!!.id
+        userRepository.softDelete(id)
+        assertNull(userRepository.findById(id))
+        assertNull(userRepository.findByUsername("john"))
+        assertTrue(userRepository.findAll().none { it.id == id })
+    }
+
+    @Test
+    fun `manages user privileges`() {
+        // Ensure first user takes pre-seeded privileges
+        userRepository.save("seed", "pw")
+        userRepository.save("mike", "pw")
+        val mikeId = userRepository.findByUsername("mike")!!.id
+
+        val privilegeMap = userRepository.findAllPrivileges().associateBy { it.name }
+        val dashboard = privilegeMap["dashboard"]!!
+        val users = privilegeMap["users"]!!
+
+        userRepository.addPrivilege(mikeId, dashboard.id)
+        var user = userRepository.findById(mikeId)
+        assertEquals(listOf(dashboard), user?.privileges)
+
+        userRepository.updateUserPrivileges(mikeId, listOf(users.id))
+        user = userRepository.findById(mikeId)
+        assertEquals(listOf(users), user?.privileges)
     }
 }


### PR DESCRIPTION
## Summary
- extend `UserRepositoryIT` with coverage for soft deletes and privilege updates
- verify soft-deleted users cannot be fetched by username

## Testing
- `./gradlew test --no-daemon`
- `DISABLE_TESTCONTAINERS=true ./gradlew integrationTest --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68a8f8673278832b8887f7fbc3b43425