### PR TITLE
Add integration tests for PrivilegeRepository

### DIFF
--- a/backend/src/test/kotlin/com/example/codex/repository/PrivilegeRepositoryIT.kt
+++ b/backend/src/test/kotlin/com/example/codex/repository/PrivilegeRepositoryIT.kt
@@ -1,0 +1,40 @@
+package com.example.codex.repository
+
+import com.example.codex.AbstractIntegrationTest
+import com.example.codex.domain.Privilege
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class PrivilegeRepositoryIT @Autowired constructor(
+    private val privilegeRepository: PrivilegeRepository,
+) : AbstractIntegrationTest() {
+
+    @Test
+    fun `performs CRUD operations`() {
+        // insert
+        val privilege = Privilege(999L, "reports")
+        privilegeRepository.insert(privilege)
+
+        // find all
+        val all = privilegeRepository.findAll()
+        assertTrue(all.any { it.id == 999L && it.name == "reports" })
+
+        // find by id
+        val found = privilegeRepository.findById(999L)
+        assertNotNull(found)
+        assertEquals("reports", found?.name)
+
+        // update
+        val updatedPrivilege = Privilege(999L, "reports-updated")
+        privilegeRepository.update(updatedPrivilege)
+        val updated = privilegeRepository.findById(999L)
+        assertEquals("reports-updated", updated?.name)
+
+        // delete
+        privilegeRepository.delete(999L)
+        val deleted = privilegeRepository.findById(999L)
+        assertNull(deleted)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add comprehensive integration test for PrivilegeRepository covering insert, read, update, and delete operations

## Testing
- `./gradlew test --no-daemon`
- `./gradlew integrationTest --no-daemon` *(fails: Docker not available)*
- `DISABLE_TESTCONTAINERS=true ./gradlew integrationTest --no-daemon` *(fails: Connection refused to Postgres)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fc6b36b0832ba57644e70ef1bc0b