### PR TITLE
Add UserService integration test with coverage

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import nu.studer.gradle.jooq.JooqEdition
 import org.jooq.meta.jaxb.Property
 import org.gradle.api.tasks.testing.Test
+import java.math.BigDecimal
 plugins {
     kotlin("jvm") version "2.0.0"
     id("org.jetbrains.kotlin.plugin.spring") version "2.1.21"
@@ -10,6 +11,7 @@ plugins {
     id("io.spring.dependency-management") version "1.1.0"
     id("org.liquibase.gradle") version "2.2.1"
     id("nu.studer.jooq") version "8.2"
+    jacoco
 }
 
 group = "com.example"
@@ -63,6 +65,29 @@ val integrationTest by tasks.registering(Test::class) {
 }
 
 tasks.check { dependsOn(integrationTest) }
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test, integrationTest)
+    executionData.setFrom(fileTree(buildDir).include("jacoco/test.exec", "jacoco/integrationTest.exec"))
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+}
+
+tasks.jacocoTestCoverageVerification {
+    dependsOn(tasks.test, integrationTest)
+    executionData.setFrom(fileTree(buildDir).include("jacoco/test.exec", "jacoco/integrationTest.exec"))
+    violationRules {
+        rule {
+            element = "CLASS"
+            includes = listOf("com.example.codex.service.UserService")
+            limit {
+                minimum = BigDecimal("0.8")
+            }
+        }
+    }
+}
 
 jooq {
     version.set("3.20.0")

--- a/backend/src/test/kotlin/com/example/codex/service/UserServiceIT.kt
+++ b/backend/src/test/kotlin/com/example/codex/service/UserServiceIT.kt
@@ -1,0 +1,35 @@
+package com.example.codex.service
+
+import com.example.codex.AbstractIntegrationTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class UserServiceIT @Autowired constructor(
+    private val userService: UserService,
+) : AbstractIntegrationTest() {
+
+    @Test
+    fun `registers, updates privileges and deletes user`() {
+        userService.register("sarah", "secret")
+        val user = userService.findByUsername("sarah")
+        assertNotNull(user)
+        val id = user!!.id
+        assertTrue(userService.allUsers().any { it.id == id })
+
+        val privileges = userService.allPrivileges().associateBy { it.name }
+        val dashboard = privileges["dashboard"]!!
+        val users = privileges["users"]!!
+
+        userService.updatePrivileges(id, listOf(dashboard.id, users.id))
+        val updated = userService.find(id)
+        assertEquals(setOf(dashboard, users), updated?.privileges?.toSet())
+
+        userService.delete(id)
+        assertNull(userService.find(id))
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Jacoco coverage tasks and verification for UserService
- create integration test exercising user registration, privilege update, and deletion

## Testing
- `./gradlew test --no-daemon --console=plain`
- `./gradlew integrationTest --no-daemon --console=plain` *(fails: IllegalStateException at DockerClientProviderStrategy)*
- `DISABLE_TESTCONTAINERS=true ./gradlew integrationTest --no-daemon --console=plain`
- `DISABLE_TESTCONTAINERS=true ./gradlew jacocoTestReport jacocoTestCoverageVerification --no-daemon --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68a9037295e4832bbba13dcb541af811