### PR TITLE
Ensure tests run after clean

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -48,6 +48,14 @@ tasks.withType<Test> {
     useJUnitPlatform()
 }
 
+tasks.named<Test>("test") {
+    dependsOn("clean")
+}
+
+tasks.matching { it.name != "clean" }.configureEach {
+    mustRunAfter("clean")
+}
+
 jooq {
     version.set("3.20.0")
     edition.set(JooqEdition.OSS)


### PR DESCRIPTION
## Summary
- Ensure the `test` task always runs after a `clean`
- Force all tasks to execute after `clean` when scheduled

## Testing
- `./gradlew test --no-daemon` *(fails: IllegalStateException at DockerClientProviderStrategy)*

------
https://chatgpt.com/codex/tasks/task_e_68a90b97e5f0832bbe22c59603bd7d4a