### PR TITLE
Add Spotless plugin to backend

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,8 +1,8 @@
+import nu.studer.gradle.jooq.JooqEdition
+import org.gradle.api.tasks.testing.Test
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import nu.studer.gradle.jooq.JooqEdition
 import org.jooq.meta.jaxb.Property
-import org.gradle.api.tasks.testing.Test
 import java.math.BigDecimal
 plugins {
     kotlin("jvm") version "2.0.0"
@@ -11,6 +11,7 @@ plugins {
     id("io.spring.dependency-management") version "1.1.0"
     id("org.liquibase.gradle") version "2.2.1"
     id("nu.studer.jooq") version "8.2"
+    id("com.diffplug.spotless") version "6.25.0"
     jacoco
 }
 
@@ -44,6 +45,18 @@ dependencies {
     testImplementation("org.testcontainers:postgresql")
 }
 
+spotless {
+    kotlin {
+        target("src/**/*.kt")
+        targetExclude("src/main/generated/**")
+        ktlint("1.7.1")
+    }
+    kotlinGradle {
+        target("*.kts")
+        ktlint("1.7.1")
+    }
+}
+
 tasks.withType<Test> {
     useJUnitPlatform()
 }
@@ -59,14 +72,18 @@ jooq {
                     name = "org.jooq.codegen.KotlinGenerator"
                     database.apply {
                         name = "org.jooq.meta.extensions.liquibase.LiquibaseDatabase"
-                        properties.add(Property().apply {
-                            key = "rootPath"
-                            value = "${projectDir}/src/main/resources"
-                        })
-						properties.add(Property().apply {
-                            key = "scripts"
-                            value = "db/changelog/db.changelog-master.yaml"
-                        })
+                        properties.add(
+                            Property().apply {
+                                key = "rootPath"
+                                value = "$projectDir/src/main/resources"
+                            },
+                        )
+                        properties.add(
+                            Property().apply {
+                                key = "scripts"
+                                value = "db/changelog/db.changelog-master.yaml"
+                            },
+                        )
                     }
                     target.apply {
                         packageName = "com.example.codex.jooq"
@@ -91,9 +108,6 @@ jooq {
         }
     }
 }
-
-
-
 
 tasks.withType<KotlinCompile> {
     compilerOptions {

--- a/backend/src/main/kotlin/com/example/codex/controller/PrivilegeController.kt
+++ b/backend/src/main/kotlin/com/example/codex/controller/PrivilegeController.kt
@@ -2,12 +2,17 @@ package com.example.codex.controller
 
 import com.example.codex.domain.Privilege
 import com.example.codex.service.UserService
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.CrossOrigin
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/privileges")
 @CrossOrigin(origins = ["*"])
-class PrivilegeController(private val userService: UserService) {
+class PrivilegeController(
+    private val userService: UserService,
+) {
     @GetMapping
     fun list(): List<Privilege> = userService.allPrivileges()
 }

--- a/backend/src/main/kotlin/com/example/codex/controller/UserController.kt
+++ b/backend/src/main/kotlin/com/example/codex/controller/UserController.kt
@@ -2,36 +2,53 @@ package com.example.codex.controller
 
 import com.example.codex.domain.User
 import com.example.codex.service.UserService
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.CrossOrigin
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/users")
 @CrossOrigin(origins = ["*"])
-class UserController(private val userService: UserService) {
-
+class UserController(
+    private val userService: UserService,
+) {
     @GetMapping
     fun list(): List<User> = userService.allUsers()
 
     @GetMapping("/{id}")
-    fun find(@PathVariable id: Long): User? = userService.find(id)
+    fun find(
+        @PathVariable id: Long,
+    ): User? = userService.find(id)
 
     @PostMapping("/register")
-    fun register(@RequestParam username: String, @RequestParam password: String) {
+    fun register(
+        @RequestParam username: String,
+        @RequestParam password: String,
+    ) {
         userService.register(username, password)
     }
 
     @DeleteMapping("/{id}")
-    fun delete(@PathVariable id: Long) {
+    fun delete(
+        @PathVariable id: Long,
+    ) {
         userService.delete(id)
     }
 
     @GetMapping("/me")
-    fun me(principal: java.security.Principal): User? {
-        return userService.findByUsername(principal.name)
-    }
+    fun me(principal: java.security.Principal): User? = userService.findByUsername(principal.name)
 
     @PostMapping("/{id}/privileges")
-    fun updatePrivileges(@PathVariable id: Long, @RequestBody privilegeIds: List<Long>) {
+    fun updatePrivileges(
+        @PathVariable id: Long,
+        @RequestBody privilegeIds: List<Long>,
+    ) {
         userService.updatePrivileges(id, privilegeIds)
     }
 }

--- a/backend/src/test/kotlin/com/example/codex/repository/PrivilegeRepositoryIT.kt
+++ b/backend/src/test/kotlin/com/example/codex/repository/PrivilegeRepositoryIT.kt
@@ -2,39 +2,42 @@ package com.example.codex.repository
 
 import com.example.codex.AbstractIntegrationTest
 import com.example.codex.domain.Privilege
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 
-class PrivilegeRepositoryIT @Autowired constructor(
-    private val privilegeRepository: PrivilegeRepository,
-) : AbstractIntegrationTest() {
+class PrivilegeRepositoryIT
+    @Autowired
+    constructor(
+        private val privilegeRepository: PrivilegeRepository,
+    ) : AbstractIntegrationTest() {
+        @Test
+        fun `performs CRUD operations`() {
+            // insert
+            val privilege = Privilege(999L, "reports")
+            privilegeRepository.insert(privilege)
 
-    @Test
-    fun `performs CRUD operations`() {
-        // insert
-        val privilege = Privilege(999L, "reports")
-        privilegeRepository.insert(privilege)
+            // find all
+            val all = privilegeRepository.findAll()
+            assertTrue(all.any { it.id == 999L && it.name == "reports" })
 
-        // find all
-        val all = privilegeRepository.findAll()
-        assertTrue(all.any { it.id == 999L && it.name == "reports" })
+            // find by id
+            val found = privilegeRepository.findById(999L)
+            assertNotNull(found)
+            assertEquals("reports", found?.name)
 
-        // find by id
-        val found = privilegeRepository.findById(999L)
-        assertNotNull(found)
-        assertEquals("reports", found?.name)
+            // update
+            val updatedPrivilege = Privilege(999L, "reports-updated")
+            privilegeRepository.update(updatedPrivilege)
+            val updated = privilegeRepository.findById(999L)
+            assertEquals("reports-updated", updated?.name)
 
-        // update
-        val updatedPrivilege = Privilege(999L, "reports-updated")
-        privilegeRepository.update(updatedPrivilege)
-        val updated = privilegeRepository.findById(999L)
-        assertEquals("reports-updated", updated?.name)
-
-        // delete
-        privilegeRepository.delete(999L)
-        val deleted = privilegeRepository.findById(999L)
-        assertNull(deleted)
+            // delete
+            privilegeRepository.delete(999L)
+            val deleted = privilegeRepository.findById(999L)
+            assertNull(deleted)
+        }
     }
-}
-


### PR DESCRIPTION
## Summary
- add Spotless plugin with ktlint formatting for Kotlin and Gradle scripts
- replace wildcard imports with explicit ones to satisfy lint rules

## Testing
- `./gradlew spotlessApply --no-daemon --console=plain`
- `./gradlew test --no-daemon --console=plain` *(fails: Docker client not available)*
- `DISABLE_TESTCONTAINERS=true ./gradlew test --no-daemon --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68a90bd2f754832bbd52390621ab4622