### PR TITLE
Add integration test for PrivilegeController

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:postgresql")
 }

--- a/backend/src/test/kotlin/com/example/codex/controller/PrivilegeControllerIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/example/codex/controller/PrivilegeControllerIntegrationTest.kt
@@ -1,0 +1,35 @@
+package com.example.codex.controller
+
+import com.example.codex.AbstractIntegrationTest
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic
+
+@AutoConfigureMockMvc
+class PrivilegeControllerIntegrationTest : AbstractIntegrationTest() {
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `should list privileges`() {
+        mockMvc
+            .perform(
+                post("/api/users/register")
+                    .param("username", "testuser")
+                    .param("password", "password"),
+            ).andExpect(status().isOk)
+
+        mockMvc
+            .perform(get("/api/privileges").with(httpBasic("testuser", "password")))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$[?(@.name == 'dashboard')]").exists())
+            .andExpect(jsonPath("$[?(@.name == 'users')]").exists())
+    }
+}
+


### PR DESCRIPTION
## Summary
- add integration test for PrivilegeController verifying privilege list retrieval after registering a user
- include Spring Security test dependency to enable HTTP basic auth in tests

## Testing
- `DISABLE_TESTCONTAINERS=true ./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68a90f4d1f58832ba019154d36cf341f