### PR TITLE
Add UserController integration test

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:postgresql")
 }

--- a/backend/src/test/kotlin/com/example/codex/controller/UserControllerIT.kt
+++ b/backend/src/test/kotlin/com/example/codex/controller/UserControllerIT.kt
@@ -1,0 +1,36 @@
+package com.example.codex.controller
+
+import com.example.codex.AbstractIntegrationTest
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+
+@AutoConfigureMockMvc
+class UserControllerIT @Autowired constructor(
+    private val mockMvc: MockMvc,
+) : AbstractIntegrationTest() {
+    @Test
+    fun `registers user and returns it from me`() {
+        val username = "user-" + UUID.randomUUID()
+
+        mockMvc
+            .perform(
+                post("/api/users/register")
+                    .param("username", username)
+                    .param("password", "secret"),
+            )
+            .andExpect(status().isOk)
+
+        mockMvc
+            .perform(get("/api/users/me").with(httpBasic(username, "secret")))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.username").value(username))
+    }
+}


### PR DESCRIPTION
## Summary
- add integration test exercising user registration and `/api/users/me`
- include Spring Security test utilities

## Testing
- `DISABLE_TESTCONTAINERS=true ./gradlew test --no-daemon` *(fails: DuplicateKeyException)*
- `SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5432/postgresTest SPRING_DATASOURCE_USERNAME=postgres SPRING_DATASOURCE_PASSWORD=postgres DISABLE_TESTCONTAINERS=true ./gradlew test --no-daemon --tests com.example.codex.controller.UserControllerIT`


------
https://chatgpt.com/codex/tasks/task_e_68a90f643748832bb6bc1ce51caf2f60