### PR TITLE
Run integration tests in parallel with isolated databases

### DIFF
--- a/backend/src/test/kotlin/com/example/codex/AbstractIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/example/codex/AbstractIntegrationTest.kt
@@ -11,7 +11,7 @@ import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
 
 @SpringBootTest
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 abstract class AbstractIntegrationTest {
     companion object {
         private val useTestcontainers = System.getenv("DISABLE_TESTCONTAINERS") != "true"

--- a/backend/src/test/kotlin/com/example/codex/AbstractIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/example/codex/AbstractIntegrationTest.kt
@@ -2,11 +2,16 @@ package com.example.codex
 
 import org.junit.jupiter.api.BeforeAll
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.testcontainers.containers.PostgreSQLContainer
+import java.sql.DriverManager
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
 
 @SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 abstract class AbstractIntegrationTest {
     companion object {
         private val useTestcontainers = System.getenv("DISABLE_TESTCONTAINERS") != "true"
@@ -16,6 +21,7 @@ abstract class AbstractIntegrationTest {
                 withUsername("codex")
                 withPassword("codex")
             }
+        private val counter = AtomicInteger()
 
         @JvmStatic
         @BeforeAll
@@ -28,17 +34,30 @@ abstract class AbstractIntegrationTest {
         @JvmStatic
         @DynamicPropertySource
         fun datasourceConfig(registry: DynamicPropertyRegistry) {
+            val db = "testdb_${counter.incrementAndGet()}"
+            val schema = "tests_${UUID.randomUUID().toString().replace("-", "")}" 
             if (useTestcontainers) {
-                registry.add("spring.datasource.url", postgres::getJdbcUrl)
+                postgres.createConnection("").use { conn ->
+                    conn.createStatement().use { it.execute("CREATE DATABASE $db") }
+                }
+                val jdbcUrl = postgres.jdbcUrl.replace("codex", db)
+                DriverManager.getConnection(jdbcUrl, postgres.username, postgres.password).use { conn ->
+                    conn.createStatement().use { it.execute("CREATE SCHEMA $schema") }
+                }
+                registry.add("spring.datasource.url") { "$jdbcUrl?currentSchema=$schema" }
                 registry.add("spring.datasource.username", postgres::getUsername)
                 registry.add("spring.datasource.password", postgres::getPassword)
             } else {
-                registry.add("spring.datasource.url") {
-                    System.getenv("SPRING_DATASOURCE_URL")
-                        ?: "jdbc:postgresql://localhost:5432/postgresTest"
+                val baseUrl =
+                    System.getenv("SPRING_DATASOURCE_URL") ?: "jdbc:postgresql://localhost:5432/postgresTest"
+                val username = System.getenv("SPRING_DATASOURCE_USERNAME") ?: "postgres"
+                val password = System.getenv("SPRING_DATASOURCE_PASSWORD") ?: "postgres"
+                DriverManager.getConnection(baseUrl, username, password).use { conn ->
+                    conn.createStatement().use { it.execute("CREATE SCHEMA $schema") }
                 }
-                registry.add("spring.datasource.username") { System.getenv("SPRING_DATASOURCE_USERNAME") ?: "postgres" }
-                registry.add("spring.datasource.password") { System.getenv("SPRING_DATASOURCE_PASSWORD") ?: "postgres" }
+                registry.add("spring.datasource.url") { "$baseUrl?currentSchema=$schema" }
+                registry.add("spring.datasource.username") { username }
+                registry.add("spring.datasource.password") { password }
             }
         }
     }

--- a/backend/src/test/resources/junit-platform.properties
+++ b/backend/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.mode.classes.default=concurrent


### PR DESCRIPTION
## Summary
- Configure JUnit Platform to run tests in parallel
- Generate a fresh PostgreSQL database and schema for each integration test
- Maintain ability to disable Testcontainers via `DISABLE_TESTCONTAINERS`

## Testing
- `DISABLE_TESTCONTAINERS=true ./gradlew test --no-daemon` *(fails: org.jooq.exception.DataAccessException due to missing local PostgreSQL)*
- `./gradlew test --no-daemon` *(fails: Docker client not available for Testcontainers)*

------
https://chatgpt.com/codex/tasks/task_e_68a920f512d4832b8186c94b42e2a1cc