### PR TITLE
Enable parallel integration tests with isolated schemas

### DIFF
--- a/backend/src/test/kotlin/com/example/codex/AbstractIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/example/codex/AbstractIntegrationTest.kt
@@ -1,7 +1,5 @@
 package com.example.codex
 
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.util.TestPropertyValues
@@ -17,20 +15,13 @@ import java.util.UUID
 
 @SpringBootTest
 @ContextConfiguration(initializers = [AbstractIntegrationTest.Companion.Initializer::class])
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 abstract class AbstractIntegrationTest {
     @Autowired
     lateinit var jdbcTemplate: JdbcTemplate
 
     @Autowired
     lateinit var env: Environment
-
-    @BeforeEach
-    fun switchSchema() {
-        val schema = env.getRequiredProperty("test.schema")
-        jdbcTemplate.execute("SET search_path TO $schema")
-    }
 
     companion object {
         private val useTestcontainers = System.getenv("DISABLE_TESTCONTAINERS") != "true"

--- a/backend/src/test/kotlin/com/example/codex/AbstractIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/example/codex/AbstractIntegrationTest.kt
@@ -1,45 +1,64 @@
 package com.example.codex
 
-import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.DynamicPropertyRegistry
-import org.springframework.test.context.DynamicPropertySource
+import org.springframework.context.ApplicationContextInitializer
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.boot.test.util.TestPropertyValues
 import org.testcontainers.containers.PostgreSQLContainer
+import java.sql.DriverManager
+import java.util.UUID
 
 @SpringBootTest
+@ContextConfiguration(initializers = [AbstractIntegrationTest.Companion.Initializer::class])
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class AbstractIntegrationTest {
     companion object {
         private val useTestcontainers = System.getenv("DISABLE_TESTCONTAINERS") != "true"
-        private val postgres =
-            PostgreSQLContainer<Nothing>("postgres:16-alpine").apply {
-                withDatabaseName("codex")
-                withUsername("codex")
-                withPassword("codex")
-            }
 
-        @JvmStatic
-        @BeforeAll
-        fun startContainer() {
-            if (useTestcontainers && !postgres.isRunning) {
-                postgres.start()
-            }
-        }
-
-        @JvmStatic
-        @DynamicPropertySource
-        fun datasourceConfig(registry: DynamicPropertyRegistry) {
-            if (useTestcontainers) {
-                registry.add("spring.datasource.url", postgres::getJdbcUrl)
-                registry.add("spring.datasource.username", postgres::getUsername)
-                registry.add("spring.datasource.password", postgres::getPassword)
-            } else {
-                registry.add("spring.datasource.url") {
-                    System.getenv("SPRING_DATASOURCE_URL")
-                        ?: "jdbc:postgresql://localhost:5432/postgresTest"
+        class Initializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
+            override fun initialize(context: ConfigurableApplicationContext) {
+                val schema = "test_${UUID.randomUUID().toString().replace("-", "")}" 
+                if (useTestcontainers) {
+                    val postgres =
+                        PostgreSQLContainer<Nothing>("postgres:16-alpine").apply {
+                            withDatabaseName("codex")
+                            withUsername("codex")
+                            withPassword("codex")
+                            start()
+                        }
+                    createSchema(postgres.jdbcUrl, postgres.username, postgres.password, schema)
+                    TestPropertyValues.of(
+                        "spring.datasource.url=${postgres.jdbcUrl}?currentSchema=$schema",
+                        "spring.datasource.username=${postgres.username}",
+                        "spring.datasource.password=${postgres.password}",
+                    ).applyTo(context.environment)
+                    context.beanFactory.registerSingleton("postgresContainer", postgres)
+                } else {
+                    val url = System.getenv("SPRING_DATASOURCE_URL") ?: "jdbc:postgresql://localhost:5432/postgresTest"
+                    val username = System.getenv("SPRING_DATASOURCE_USERNAME") ?: "postgres"
+                    val password = System.getenv("SPRING_DATASOURCE_PASSWORD") ?: "postgres"
+                    createSchema(url, username, password, schema)
+                    val sep = if (url.contains("?")) "&" else "?"
+                    TestPropertyValues.of(
+                        "spring.datasource.url=$url${sep}currentSchema=$schema",
+                        "spring.datasource.username=$username",
+                        "spring.datasource.password=$password",
+                    ).applyTo(context.environment)
                 }
-                registry.add("spring.datasource.username") { System.getenv("SPRING_DATASOURCE_USERNAME") ?: "postgres" }
-                registry.add("spring.datasource.password") { System.getenv("SPRING_DATASOURCE_PASSWORD") ?: "postgres" }
+            }
+
+            private fun createSchema(url: String, username: String, password: String, schema: String) {
+                DriverManager.getConnection(url, username, password).use { conn ->
+                    conn.createStatement().use { stmt ->
+                        stmt.execute("CREATE SCHEMA IF NOT EXISTS $schema")
+                    }
+                }
             }
         }
     }
 }
+

--- a/backend/src/test/kotlin/com/example/codex/AbstractIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/example/codex/AbstractIntegrationTest.kt
@@ -1,12 +1,16 @@
 package com.example.codex
 
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.util.TestPropertyValues
 import org.springframework.context.ApplicationContextInitializer
 import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.core.env.Environment
+import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ContextConfiguration
-import org.springframework.boot.test.util.TestPropertyValues
 import org.testcontainers.containers.PostgreSQLContainer
 import java.sql.DriverManager
 import java.util.UUID
@@ -16,6 +20,18 @@ import java.util.UUID
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class AbstractIntegrationTest {
+    @Autowired
+    lateinit var jdbcTemplate: JdbcTemplate
+
+    @Autowired
+    lateinit var env: Environment
+
+    @BeforeEach
+    fun switchSchema() {
+        val schema = env.getRequiredProperty("test.schema")
+        jdbcTemplate.execute("SET search_path TO $schema")
+    }
+
     companion object {
         private val useTestcontainers = System.getenv("DISABLE_TESTCONTAINERS") != "true"
 
@@ -35,6 +51,7 @@ abstract class AbstractIntegrationTest {
                         "spring.datasource.url=${postgres.jdbcUrl}?currentSchema=$schema",
                         "spring.datasource.username=${postgres.username}",
                         "spring.datasource.password=${postgres.password}",
+                        "test.schema=$schema",
                     ).applyTo(context.environment)
                     context.beanFactory.registerSingleton("postgresContainer", postgres)
                 } else {
@@ -47,6 +64,7 @@ abstract class AbstractIntegrationTest {
                         "spring.datasource.url=$url${sep}currentSchema=$schema",
                         "spring.datasource.username=$username",
                         "spring.datasource.password=$password",
+                        "test.schema=$schema",
                     ).applyTo(context.environment)
                 }
             }

--- a/backend/src/test/kotlin/com/example/codex/SchemaIsolationIT.kt
+++ b/backend/src/test/kotlin/com/example/codex/SchemaIsolationIT.kt
@@ -1,0 +1,13 @@
+package com.example.codex
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+
+class SchemaIsolationIT : AbstractIntegrationTest() {
+    @Test
+    fun usesSchemaFromInitializer() {
+        val expected = env.getRequiredProperty("test.schema")
+        val current = jdbcTemplate.queryForObject("SELECT current_schema()", String::class.java)
+        assertEquals(expected, current)
+    }
+}

--- a/backend/src/test/resources/junit-platform.properties
+++ b/backend/src/test/resources/junit-platform.properties
@@ -1,0 +1,4 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.mode.classes.default=concurrent
+


### PR DESCRIPTION
## Summary
- run JUnit tests concurrently by enabling parallel execution
- initialize a fresh Postgres schema for each test method while preserving `DISABLE_TESTCONTAINERS` logic

## Testing
- `DISABLE_TESTCONTAINERS=true ./gradlew test --no-daemon` (fails: org.jooq.exception.DataAccessException)
- `./gradlew test --no-daemon` (fails: DockerClientProviderStrategy)


------
https://chatgpt.com/codex/tasks/task_e_68a95d1941a0832ba13eb27928354970