### PR TITLE
Enable parallel execution for tests

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -60,6 +60,7 @@ spotless {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    maxParallelForks = Runtime.getRuntime().availableProcessors()
 }
 
 tasks.named<Test>("test") {

--- a/backend/src/test/resources/junit-platform.properties
+++ b/backend/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.mode.classes.default=concurrent


### PR DESCRIPTION
## Summary
- Configure Gradle test tasks to leverage all available processors for concurrent execution.
- Enable JUnit 5 parallel mode via `junit-platform.properties`.

## Testing
- `DISABLE_TESTCONTAINERS=true ./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68aa3a47c640832bbb8a80525d444487