### PR TITLE
test: run integration tests in parallel with isolated schemas

### DIFF
--- a/backend/src/test/kotlin/com/example/codex/AbstractIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/example/codex/AbstractIntegrationTest.kt
@@ -1,10 +1,21 @@
 package com.example.codex
 
+import jakarta.annotation.PostConstruct
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.jooq.DSLContext
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestInfo
+import org.mockito.Mockito
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.testcontainers.containers.PostgreSQLContainer
+import liquibase.integration.spring.SpringLiquibase
+import java.util.UUID
+import javax.sql.DataSource
 
 @SpringBootTest
 abstract class AbstractIntegrationTest {
@@ -40,6 +51,36 @@ abstract class AbstractIntegrationTest {
                 registry.add("spring.datasource.username") { System.getenv("SPRING_DATASOURCE_USERNAME") ?: "postgres" }
                 registry.add("spring.datasource.password") { System.getenv("SPRING_DATASOURCE_PASSWORD") ?: "postgres" }
             }
+        }
+    }
+
+    @SpyBean
+    protected lateinit var dataSource: DataSource
+
+    @SpyBean
+    protected lateinit var dslContext: DSLContext
+
+    @PostConstruct
+    fun initDataSourceSpy() {
+        Mockito.doAnswer { invocation ->
+            val conn = invocation.callRealMethod() as java.sql.Connection
+            val schema = SchemaContext.get()
+            conn.createStatement().use { it.execute("set search_path to \"$schema\"") }
+            conn
+        }.`when`(dataSource).connection
+    }
+
+    @BeforeEach
+    fun prepareSchema(testInfo: TestInfo) {
+        val schema = "test_" + UUID.randomUUID().toString().replace("-", "")
+        SchemaContext.set("public")
+        dslContext.execute("create schema if not exists \"$schema\"")
+        SchemaContext.set(schema)
+        SpringLiquibase().apply {
+            changeLog = "classpath:db/changelog/db.changelog-master.yaml"
+            dataSource = this@AbstractIntegrationTest.dataSource
+            defaultSchema = schema
+            afterPropertiesSet()
         }
     }
 }

--- a/backend/src/test/kotlin/com/example/codex/SchemaContext.kt
+++ b/backend/src/test/kotlin/com/example/codex/SchemaContext.kt
@@ -1,0 +1,8 @@
+package com.example.codex
+
+object SchemaContext {
+    private val current = ThreadLocal<String?>()
+
+    fun set(schema: String) = current.set(schema)
+    fun get(): String = current.get() ?: "public"
+}

--- a/backend/src/test/resources/junit-platform.properties
+++ b/backend/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.mode.classes.default=concurrent


### PR DESCRIPTION
## Summary
- enable JUnit 5 parallel execution for backend integration tests
- spy the database context and create unique schema per test method
- bootstrap each schema with Liquibase migrations

## Testing
- `DISABLE_TESTCONTAINERS=true ./gradlew test --no-daemon` *(fails: LiquibaseException)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3a0b87b8832b8acad3bc2c1b6e36