### PR TITLE
feat: add back channel login

### DIFF
--- a/backend/src/main/kotlin/com/example/codex/config/Beans.kt
+++ b/backend/src/main/kotlin/com/example/codex/config/Beans.kt
@@ -1,12 +1,17 @@
 package com.example.codex.config
 
+import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.web.client.RestTemplate
 
 @Configuration
 class Beans {
     @Bean
     fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
+
+    @Bean
+    fun restTemplate(builder: RestTemplateBuilder): RestTemplate = builder.build()
 }

--- a/backend/src/main/kotlin/com/example/codex/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/com/example/codex/config/SecurityConfig.kt
@@ -24,6 +24,7 @@ class SecurityConfig(
         private val AUTH_WHITELIST =
             arrayOf(
                 "/api/users/register",
+                "/api/auth/token",
                 "/v3/api-docs/**",
                 "/swagger-ui.html",
                 "/swagger-ui/**",
@@ -31,9 +32,7 @@ class SecurityConfig(
     }
 
     @Bean
-    fun securityFilterChain(
-        http: HttpSecurity,
-    ): SecurityFilterChain {
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http
             .csrf { it.disable() }
             .cors {
@@ -45,9 +44,8 @@ class SecurityConfig(
                         allowCredentials = true
                     }
                 }
-            }
-            .sessionManagement {
-                it.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            }.sessionManagement {
+                it.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
             }.authorizeHttpRequests { authz ->
                 authz
                     .requestMatchers(*AUTH_WHITELIST)

--- a/backend/src/main/kotlin/com/example/codex/controller/AuthController.kt
+++ b/backend/src/main/kotlin/com/example/codex/controller/AuthController.kt
@@ -1,0 +1,67 @@
+package com.example.codex.controller
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import jakarta.servlet.http.HttpSession
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.web.bind.annotation.CrossOrigin
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.client.RestTemplate
+
+@RestController
+@RequestMapping("/api/auth")
+@CrossOrigin(origins = ["*"])
+class AuthController(
+    private val restTemplate: RestTemplate,
+    @Value("\${keycloak.token-uri:}")
+    private val tokenUri: String,
+    @Value("\${keycloak.client-id:}")
+    private val clientId: String,
+    @Value("\${keycloak.client-secret:}")
+    private val clientSecret: String,
+    @Value("\${keycloak.redirect-uri:}")
+    private val redirectUri: String,
+) {
+    data class CodeRequest(
+        val code: String,
+    )
+
+    data class TokenResponse(
+        @JsonProperty("access_token")
+        val accessToken: String,
+        @JsonProperty("refresh_token")
+        val refreshToken: String?,
+    )
+
+    @PostMapping("/token")
+    fun exchangeCode(
+        @RequestBody request: CodeRequest,
+        session: HttpSession,
+    ): TokenResponse {
+        val form =
+            LinkedMultiValueMap<String, String>().apply {
+                add("grant_type", "authorization_code")
+                add("code", request.code)
+                add("client_id", clientId)
+                add("client_secret", clientSecret)
+                add("redirect_uri", redirectUri)
+            }
+        val headers = HttpHeaders().apply { contentType = MediaType.APPLICATION_FORM_URLENCODED }
+        val entity = HttpEntity(form, headers)
+        val response =
+            restTemplate.postForObject(tokenUri, entity, Map::class.java)
+                ?: throw IllegalStateException("No response from token endpoint")
+        val accessToken =
+            response["access_token"] as? String
+                ?: throw IllegalStateException("Access token missing in response")
+        session.setAttribute("accessToken", accessToken)
+        val refreshToken = response["refresh_token"] as? String
+        return TokenResponse(accessToken, refreshToken)
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -8,5 +8,11 @@ spring:
 
 frontendUrl: ${FRONTEND_URL}
 
+keycloak:
+  token-uri: ${KEYCLOAK_TOKEN_URI}
+  client-id: ${KEYCLOAK_CLIENT_ID}
+  client-secret: ${KEYCLOAK_CLIENT_SECRET}
+  redirect-uri: ${KEYCLOAK_REDIRECT_URI}
+
 logging.level.org.jooq.tools.LoggerListener: DEBUG
 


### PR DESCRIPTION
## Summary
- handle authorization-code exchange against Keycloak and persist access token in HTTP session
- allow session-backed auth by whitelisting the token endpoint and enabling stateful sessions
- expose Keycloak token configuration and a RestTemplate bean for token exchange

## Testing
- `DISABLE_TESTCONTAINERS=true SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5432/postgresTest SPRING_DATASOURCE_USERNAME=postgres SPRING_DATASOURCE_PASSWORD=postgres ./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68ae0cceba8c832b8016cff7e5b524bd