### PR TITLE
Redirect to login on 401

### DIFF
--- a/frontend/src/app.component.ts
+++ b/frontend/src/app.component.ts
@@ -9,7 +9,7 @@ import { Router } from '@angular/router';
 @Component({
   selector: 'app-root',
   template: `
-    <app-top-menu [user]="auth.user" (logout)="logout()"></app-top-menu>
+    <app-top-menu [user]="auth.user" (logout)="logout()" (login)="login()"></app-top-menu>
     <mat-sidenav-container *ngIf="auth.user" class="layout">
       <mat-sidenav mode="side" opened>
         <app-navbar [user]="auth.user"></app-navbar>
@@ -32,5 +32,9 @@ export class AppComponent {
   logout() {
     this.auth.logout();
     this.router.navigate(['/login']);
+  }
+
+  login() {
+    this.auth.login();
   }
 }

--- a/frontend/src/auth.service.ts
+++ b/frontend/src/auth.service.ts
@@ -36,13 +36,31 @@ export class AuthService {
   }
 
   async request(url: string, options: RequestInit = {}) {
-    options.headers = { ...(options.headers || {}), ...this.authHeaders() };
-    const res = await fetch(url, options);
-    if (res.status === 401) {
-      this.keycloak.clearToken();
-      this.user = undefined;
-      this.router.navigate(['/login']);
+    try {
+      await this.keycloak.updateToken(5);
+    } catch (_) {
+      this.handleUnauthorized();
+      throw _;
     }
+
+    options.headers = { ...(options.headers || {}), ...this.authHeaders() };
+    let res = await fetch(url, options);
+
+    if (res.status === 401) {
+      try {
+        await this.keycloak.updateToken(0);
+        options.headers = { ...(options.headers || {}), ...this.authHeaders() };
+        res = await fetch(url, options);
+      } catch (_) {
+        this.handleUnauthorized();
+        return res;
+      }
+
+      if (res.status === 401) {
+        this.handleUnauthorized();
+      }
+    }
+
     return res;
   }
 
@@ -51,5 +69,11 @@ export class AuthService {
     if (res.ok) {
       this.user = await res.json();
     }
+  }
+
+  private handleUnauthorized() {
+    this.keycloak.clearToken();
+    this.user = undefined;
+    this.router.navigate(['/login']);
   }
 }

--- a/frontend/src/auth.service.ts
+++ b/frontend/src/auth.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import Keycloak from 'keycloak-js';
+import { Router } from '@angular/router';
 import { User } from './app.component';
 
 @Injectable({ providedIn: 'root' })
@@ -8,7 +9,7 @@ export class AuthService {
   API_URL = (window as any).API_URL || 'http://localhost:8081';
   keycloak: any;
 
-  constructor() {
+  constructor(private router: Router) {
     this.keycloak = new Keycloak({
       url: (window as any).KEYCLOAK_URL || 'http://localhost:30001',
       realm: (window as any).KEYCLOAK_REALM || 'codex',
@@ -30,12 +31,23 @@ export class AuthService {
     this.keycloak.logout();
   }
 
-  authHeaders() {
+  private authHeaders() {
     return { 'Authorization': 'Bearer ' + this.keycloak.token, 'Content-Type': 'application/json' };
   }
 
+  async request(url: string, options: RequestInit = {}) {
+    options.headers = { ...(options.headers || {}), ...this.authHeaders() };
+    const res = await fetch(url, options);
+    if (res.status === 401) {
+      this.keycloak.clearToken();
+      this.user = undefined;
+      this.router.navigate(['/login']);
+    }
+    return res;
+  }
+
   private async loadUser() {
-    const res = await fetch(`${this.API_URL}/api/users/me`, { headers: this.authHeaders() });
+    const res = await this.request(`${this.API_URL}/api/users/me`);
     if (res.ok) {
       this.user = await res.json();
     }

--- a/frontend/src/top-menu.component.ts
+++ b/frontend/src/top-menu.component.ts
@@ -13,7 +13,10 @@ import { TranslationService, Lang } from './i18n/translation.service';
         <mat-option value="en">EN</mat-option>
         <mat-option value="hu">HU</mat-option>
       </mat-select>
-      <button mat-button *ngIf="user" (click)="logout.emit()">{{ 'LOGOUT' | t }}</button>
+      <button mat-button *ngIf="user; else loginBtn" (click)="logout.emit()">{{ 'LOGOUT' | t }}</button>
+      <ng-template #loginBtn>
+        <button mat-button (click)="login.emit()">{{ 'LOGIN' | t }}</button>
+      </ng-template>
     </mat-toolbar>
   `,
   styles: [`
@@ -25,6 +28,7 @@ import { TranslationService, Lang } from './i18n/translation.service';
 export class TopMenuComponent {
   @Input() user?: User;
   @Output() logout = new EventEmitter<void>();
+  @Output() login = new EventEmitter<void>();
   dark = localStorage.getItem('darkMode') === 'true';
   lang: Lang;
 

--- a/frontend/src/user-edit.component.ts
+++ b/frontend/src/user-edit.component.ts
@@ -42,10 +42,10 @@ export class UserEditComponent implements OnInit {
 
   ngOnInit() {
     const id = Number(this.route.snapshot.paramMap.get('id'));
-    fetch(`${this.auth.API_URL}/api/users/${id}`, { headers: this.auth.authHeaders() })
+    this.auth.request(`${this.auth.API_URL}/api/users/${id}`)
       .then(r => r.json())
       .then((u: User) => this.user = u);
-    fetch(`${this.auth.API_URL}/api/privileges`, { headers: this.auth.authHeaders() })
+    this.auth.request(`${this.auth.API_URL}/api/privileges`)
       .then(r => r.json())
       .then((p: Privilege[]) => this.allPrivileges = p);
   }
@@ -66,9 +66,8 @@ export class UserEditComponent implements OnInit {
 
   save() {
     if (!this.user) return;
-    fetch(`${this.auth.API_URL}/api/users/${this.user.id}/privileges`, {
+    this.auth.request(`${this.auth.API_URL}/api/users/${this.user.id}/privileges`, {
       method: 'POST',
-      headers: this.auth.authHeaders(),
       body: JSON.stringify(this.user.privileges.map(pr => pr.id))
     });
   }

--- a/frontend/src/users.component.ts
+++ b/frontend/src/users.component.ts
@@ -53,12 +53,8 @@ export class UsersComponent implements OnInit, AfterViewInit {
     }
   }
 
-  private authHeaders() {
-    return this.auth.authHeaders();
-  }
-
   loadUsers() {
-    fetch(`${this.auth.API_URL}/api/users`, { headers: this.authHeaders() })
+    this.auth.request(`${this.auth.API_URL}/api/users`)
       .then(r => r.json())
       .then((d: User[]) => this.dataSource.data = d);
   }
@@ -68,9 +64,8 @@ export class UsersComponent implements OnInit, AfterViewInit {
   }
 
   deleteUser(id: number) {
-    fetch(`${this.auth.API_URL}/api/users/${id}`, {
-      method: 'DELETE',
-      headers: this.authHeaders()
+    this.auth.request(`${this.auth.API_URL}/api/users/${id}`, {
+      method: 'DELETE'
     }).then(() => this.loadUsers());
   }
 }


### PR DESCRIPTION
## Summary
- Route API requests through AuthService and intercept 401s
- Clear authentication token and navigate to login on unauthorized responses
- Update user management components to use centralized request helper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68bf317fb3fc832bb1c6002a2fd496f4