### PR TITLE
feat: use helm for deployments

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,46 +40,29 @@ pipeline {
     }
 
     stage('Deploy to dev') {
-	  when { branch 'dev' }
+      when { branch 'dev' }
       steps {
-        script {
-                  // Export both images with the current BUILD_NUMBER
-                  sh '''
-                        export IMAGE_BACKEND=${REGISTRY_URL}/codex-backend:${BUILD_NUMBER}
-                        export IMAGE_FRONTEND=${REGISTRY_URL}/codex-frontend:${BUILD_NUMBER}
-                        KUBECTL="kubectl --insecure-skip-tls-verify=true --validate=false"
-
-                        $KUBECTL apply -f kubernetes/dev/namespace.yaml
-                        # Render & apply backend YAML
-                        envsubst < kubernetes/dev/backend-deployment.yaml | $KUBECTL apply -f -
-
-                        # Render & apply frontend YAML
-                        envsubst < kubernetes/dev/frontend-deployment.yaml | $KUBECTL apply -f -
-
-                        # Apply the Postgres DB
-                        $KUBECTL apply -f kubernetes/dev/db-secret.yaml
-                        $KUBECTL apply -f kubernetes/dev/db.yaml
-                        $KUBECTL apply -f kubernetes/dev/keycloak.yaml
-                  '''
-                }
+        sh '''
+          helm upgrade --install codex helm/codex \
+            -n dev --create-namespace \
+            -f helm/codex/values.yaml \
+            --set image.backend=${IMAGE_BACKEND} \
+            --set image.frontend=${IMAGE_FRONTEND}
+        '''
       }
     }
 
     stage('Deploy to dani') {
       when { branch 'dani' }
       steps {
-        script {
-                  sh '''
-                        export IMAGE_BACKEND=${REGISTRY_URL}/codex-backend:${BUILD_NUMBER}
-                        export IMAGE_FRONTEND=${REGISTRY_URL}/codex-frontend:${BUILD_NUMBER}
-                        KUBECTL="kubectl --insecure-skip-tls-verify=true --validate=false"
-
-                        $KUBECTL apply -f kubernetes/dani/namespace.yaml
-                        envsubst < kubernetes/dani/backend-deployment.yaml | $KUBECTL apply -f -
-                        envsubst < kubernetes/dani/frontend-deployment.yaml | $KUBECTL apply -f -
-                        $KUBECTL apply -f kubernetes/dani/db.yaml
-                  '''
-                }
+        sh '''
+          helm upgrade --install codex helm/codex \
+            -n dani --create-namespace \
+            -f helm/codex/values.yaml \
+            -f helm/codex/values-dani.yaml \
+            --set image.backend=${IMAGE_BACKEND} \
+            --set image.frontend=${IMAGE_FRONTEND}
+        '''
       }
     }
 
@@ -87,7 +70,14 @@ pipeline {
       when { branch 'main' }
       steps {
         input 'Deploy to staging?'
-        sh 'kubectl --insecure-skip-tls-verify=true apply -f kubernetes/staging'
+        sh '''
+          helm upgrade --install codex helm/codex \
+            -n staging --create-namespace \
+            -f helm/codex/values.yaml \
+            -f helm/codex/values-staging.yaml \
+            --set image.backend=${IMAGE_BACKEND} \
+            --set image.frontend=${IMAGE_FRONTEND}
+        '''
       }
     }
 
@@ -95,7 +85,14 @@ pipeline {
       when { branch 'main' }
       steps {
         input 'Deploy to production?'
-        sh 'kubectl --insecure-skip-tls-verify=true apply -f kubernetes/prod'
+        sh '''
+          helm upgrade --install codex helm/codex \
+            -n prod --create-namespace \
+            -f helm/codex/values.yaml \
+            -f helm/codex/values-prod.yaml \
+            --set image.backend=${IMAGE_BACKEND} \
+            --set image.frontend=${IMAGE_FRONTEND}
+        '''
       }
     }
   }

--- a/helm/codex/Chart.yaml
+++ b/helm/codex/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: codex
+description: Helm chart for Codex application
+type: application
+version: 0.1.0
+appVersion: "1.0"

--- a/helm/codex/templates/backend.yaml
+++ b/helm/codex/templates/backend.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: codex-backend
+  labels:
+    app: codex-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: codex-backend
+  template:
+    metadata:
+      labels:
+        app: codex-backend
+    spec:
+      containers:
+        - name: backend
+          image: {{ .Values.image.backend }}
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+          env:
+{{- range $name, $value := .Values.backend.env }}
+            - name: {{ $name }}
+              value: "{{ $value }}"
+{{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: codex-backend
+  labels:
+    app: codex-backend
+spec:
+  type: {{ .Values.backend.service.type }}
+  selector:
+    app: codex-backend
+  ports:
+    - port: 80
+      targetPort: 8080
+{{- if .Values.backend.service.nodePort }}
+      nodePort: {{ .Values.backend.service.nodePort }}
+{{- end }}

--- a/helm/codex/templates/db.yaml
+++ b/helm/codex/templates/db.yaml
@@ -1,0 +1,87 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: codex-db-credentials
+  labels:
+    app: codex-db
+type: Opaque
+stringData:
+  POSTGRES_DB: {{ .Values.db.name }}
+  POSTGRES_USER: {{ .Values.db.user }}
+  POSTGRES_PASSWORD: {{ .Values.db.password }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: codex-db-pvc
+  labels:
+    app: codex-db
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.db.storage }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: codex-db
+  labels:
+    app: codex-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: codex-db
+  template:
+    metadata:
+      labels:
+        app: codex-db
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: codex-db-credentials
+                  key: POSTGRES_DB
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: codex-db-credentials
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: codex-db-credentials
+                  key: POSTGRES_PASSWORD
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: codex-db-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: codex-db
+  labels:
+    app: codex-db
+spec:
+  type: {{ .Values.db.service.type }}
+  selector:
+    app: codex-db
+  ports:
+    - port: 5432
+      targetPort: 5432
+{{- if .Values.db.service.nodePort }}
+      nodePort: {{ .Values.db.service.nodePort }}
+{{- end }}

--- a/helm/codex/templates/frontend.yaml
+++ b/helm/codex/templates/frontend.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: codex-frontend
+  labels:
+    app: codex-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: codex-frontend
+  template:
+    metadata:
+      labels:
+        app: codex-frontend
+    spec:
+      containers:
+        - name: frontend
+          image: {{ .Values.image.frontend }}
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 80
+          env:
+{{- range $name, $value := .Values.frontend.env }}
+            - name: {{ $name }}
+              value: "{{ $value }}"
+{{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: codex-frontend
+  labels:
+    app: codex-frontend
+spec:
+  type: {{ .Values.frontend.service.type }}
+  selector:
+    app: codex-frontend
+  ports:
+    - port: 80
+      targetPort: 80
+{{- if .Values.frontend.service.nodePort }}
+      nodePort: {{ .Values.frontend.service.nodePort }}
+{{- end }}

--- a/helm/codex/values-dani.yaml
+++ b/helm/codex/values-dani.yaml
@@ -1,0 +1,13 @@
+backend:
+  service:
+    nodePort: 31081
+  env:
+    FRONTEND_URL: "localhost:31080"
+frontend:
+  service:
+    nodePort: 31080
+  env:
+    API_URL: "http://localhost:31081"
+db:
+  service:
+    nodePort: 31082

--- a/helm/codex/values-prod.yaml
+++ b/helm/codex/values-prod.yaml
@@ -1,0 +1,14 @@
+backend:
+  service:
+    type: ClusterIP
+    nodePort: null
+  env: {}
+frontend:
+  service:
+    type: ClusterIP
+    nodePort: null
+  env: {}
+db:
+  service:
+    type: ClusterIP
+    nodePort: null

--- a/helm/codex/values-staging.yaml
+++ b/helm/codex/values-staging.yaml
@@ -1,0 +1,14 @@
+backend:
+  service:
+    type: ClusterIP
+    nodePort: null
+  env: {}
+frontend:
+  service:
+    type: ClusterIP
+    nodePort: null
+  env: {}
+db:
+  service:
+    type: ClusterIP
+    nodePort: null

--- a/helm/codex/values.yaml
+++ b/helm/codex/values.yaml
@@ -1,0 +1,33 @@
+image:
+  backend: ""
+  frontend: ""
+
+backend:
+  service:
+    type: NodePort
+    nodePort: 30081
+  env:
+    DB_HOST: codex-db
+    DB_PORT: "5432"
+    FRONTEND_URL: "http://localhost:30080"
+    SPRING_DATASOURCE_USERNAME: codex
+    SPRING_DATASOURCE_PASSWORD: codex
+    SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI: "http://my-keycloak-service.dev:8080/realms/codex"
+frontend:
+  service:
+    type: NodePort
+    nodePort: 30080
+  env:
+    API_URL: "http://localhost:30081"
+    KEYCLOAK_URL: "http://localhost:30001"
+    KEYCLOAK_REALM: codex
+    KEYCLOAK_CLIENT_ID: codex-frontend
+
+db:
+  name: codex
+  user: codex
+  password: codex
+  storage: 1Gi
+  service:
+    type: NodePort
+    nodePort: 30082


### PR DESCRIPTION
## Summary
- add Helm chart with backend, frontend, and database templates
- deploy dev, dani, staging, and prod via `helm upgrade --install`

## Testing
- `helm lint helm/codex`
- `helm template test helm/codex -f helm/codex/values.yaml`
- `cd backend && ./gradlew test --no-daemon --console=plain` *(fails: build aborted, see logs)*
- `cd frontend && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c088f9ddd8832b97a0fa7b362341d0