### PR TITLE
Install Helm in Jenkins image

### DIFF
--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -10,4 +10,9 @@ RUN apt-get update \
 RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
     install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
     rm kubectl
+
+RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 \
+    && chmod 700 get_helm.sh \
+    && ./get_helm.sh \
+    && rm get_helm.sh
 USER jenkins

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/jenkinsci/jenkins:lts
+FROM jenkins/jenkins:lts
 
 USER root
 RUN apt-get update \

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:lts
+FROM ghcr.io/jenkinsci/jenkins:lts
 
 USER root
 RUN apt-get update \

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/jenkinsci/jenkins:lts
 
 USER root
 RUN apt-get update \
- && apt-get install -y docker.io \
+ && apt-get install -y docker.io tar gzip \
  && rm -rf /var/lib/apt/lists/* \
  && groupadd -g 999 docker  || true \
  && usermod -aG docker jenkins


### PR DESCRIPTION
## Summary
- Install Helm in the Jenkins Docker image using the official install script

## Testing
- `docker build -t test-jenkins jenkins` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68c08f82fb78832bb7dc76b7ced2ff60