### PR TITLE
Patch resources before Helm install

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,6 +43,15 @@ pipeline {
       when { branch 'dev' }
       steps {
         sh '''
+          kubectl get secret codex-db-credentials -n dev >/dev/null 2>&1 && \
+          kubectl label secret codex-db-credentials -n dev app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate secret codex-db-credentials -n dev meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=dev --overwrite || true
+          kubectl get pvc codex-db-pvc -n dev >/dev/null 2>&1 && \
+          kubectl label pvc codex-db-pvc -n dev app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate pvc codex-db-pvc -n dev meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=dev --overwrite || true
+          kubectl get service codex-backend -n dev >/dev/null 2>&1 && \
+          kubectl label service codex-backend -n dev app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate service codex-backend -n dev meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=dev --overwrite || true
           helm upgrade --install codex helm/codex \
             -n dev --create-namespace \
             -f helm/codex/values.yaml \
@@ -56,6 +65,15 @@ pipeline {
       when { branch 'dani' }
       steps {
         sh '''
+          kubectl get secret codex-db-credentials -n dani >/dev/null 2>&1 && \
+          kubectl label secret codex-db-credentials -n dani app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate secret codex-db-credentials -n dani meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=dani --overwrite || true
+          kubectl get pvc codex-db-pvc -n dani >/dev/null 2>&1 && \
+          kubectl label pvc codex-db-pvc -n dani app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate pvc codex-db-pvc -n dani meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=dani --overwrite || true
+          kubectl get service codex-backend -n dani >/dev/null 2>&1 && \
+          kubectl label service codex-backend -n dani app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate service codex-backend -n dani meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=dani --overwrite || true
           helm upgrade --install codex helm/codex \
             -n dani --create-namespace \
             -f helm/codex/values.yaml \
@@ -71,6 +89,15 @@ pipeline {
       steps {
         input 'Deploy to staging?'
         sh '''
+          kubectl get secret codex-db-credentials -n staging >/dev/null 2>&1 && \
+          kubectl label secret codex-db-credentials -n staging app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate secret codex-db-credentials -n staging meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=staging --overwrite || true
+          kubectl get pvc codex-db-pvc -n staging >/dev/null 2>&1 && \
+          kubectl label pvc codex-db-pvc -n staging app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate pvc codex-db-pvc -n staging meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=staging --overwrite || true
+          kubectl get service codex-backend -n staging >/dev/null 2>&1 && \
+          kubectl label service codex-backend -n staging app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate service codex-backend -n staging meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=staging --overwrite || true
           helm upgrade --install codex helm/codex \
             -n staging --create-namespace \
             -f helm/codex/values.yaml \
@@ -86,6 +113,15 @@ pipeline {
       steps {
         input 'Deploy to production?'
         sh '''
+          kubectl get secret codex-db-credentials -n prod >/dev/null 2>&1 && \
+          kubectl label secret codex-db-credentials -n prod app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate secret codex-db-credentials -n prod meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=prod --overwrite || true
+          kubectl get pvc codex-db-pvc -n prod >/dev/null 2>&1 && \
+          kubectl label pvc codex-db-pvc -n prod app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate pvc codex-db-pvc -n prod meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=prod --overwrite || true
+          kubectl get service codex-backend -n prod >/dev/null 2>&1 && \
+          kubectl label service codex-backend -n prod app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate service codex-backend -n prod meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=prod --overwrite || true
           helm upgrade --install codex helm/codex \
             -n prod --create-namespace \
             -f helm/codex/values.yaml \


### PR DESCRIPTION
## Summary
- Ensure each environment patches the `codex-db-credentials` secret, `codex-db-pvc` claim, and `codex-backend` service with Helm ownership labels before running `helm upgrade --install`.

## Testing
- `npm test` *(fails: could not find package.json)*
- `cd backend && ./gradlew test --no-daemon` *(fails: 5 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c09e5d93cc832bb6d0b8ee201ddc84