### PR TITLE
Patch resources before Helm install

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,6 +43,24 @@ pipeline {
       when { branch 'dev' }
       steps {
         sh '''
+          kubectl get secret codex-db-credentials -n dev >/dev/null 2>&1 && \
+          kubectl label secret codex-db-credentials -n dev app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate secret codex-db-credentials -n dev meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=dev --overwrite || true
+          kubectl get pvc codex-db-pvc -n dev >/dev/null 2>&1 && \
+          kubectl label pvc codex-db-pvc -n dev app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate pvc codex-db-pvc -n dev meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=dev --overwrite || true
+          kubectl get service codex-backend -n dev >/dev/null 2>&1 && \
+          kubectl label service codex-backend -n dev app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate service codex-backend -n dev meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=dev --overwrite || true
+          kubectl get service codex-frontend -n dev >/dev/null 2>&1 && \
+          kubectl label service codex-frontend -n dev app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate service codex-frontend -n dev meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=dev --overwrite || true
+          kubectl get service codex-db -n dev >/dev/null 2>&1 && \
+          kubectl label service codex-db -n dev app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate service codex-db -n dev meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=dev --overwrite || true
+          kubectl get deployment codex-backend -n dev >/dev/null 2>&1 && \
+          kubectl label deployment codex-backend -n dev app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate deployment codex-backend -n dev meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=dev --overwrite || true
           helm upgrade --install codex helm/codex \
             -n dev --create-namespace \
             -f helm/codex/values.yaml \
@@ -56,6 +74,24 @@ pipeline {
       when { branch 'dani' }
       steps {
         sh '''
+          kubectl get secret codex-db-credentials -n dani >/dev/null 2>&1 && \
+          kubectl label secret codex-db-credentials -n dani app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate secret codex-db-credentials -n dani meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=dani --overwrite || true
+          kubectl get pvc codex-db-pvc -n dani >/dev/null 2>&1 && \
+          kubectl label pvc codex-db-pvc -n dani app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate pvc codex-db-pvc -n dani meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=dani --overwrite || true
+          kubectl get service codex-backend -n dani >/dev/null 2>&1 && \
+          kubectl label service codex-backend -n dani app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate service codex-backend -n dani meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=dani --overwrite || true
+          kubectl get service codex-frontend -n dani >/dev/null 2>&1 && \
+          kubectl label service codex-frontend -n dani app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate service codex-frontend -n dani meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=dani --overwrite || true
+          kubectl get service codex-db -n dani >/dev/null 2>&1 && \
+          kubectl label service codex-db -n dani app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate service codex-db -n dani meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=dani --overwrite || true
+          kubectl get deployment codex-backend -n dani >/dev/null 2>&1 && \
+          kubectl label deployment codex-backend -n dani app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate deployment codex-backend -n dani meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=dani --overwrite || true
           helm upgrade --install codex helm/codex \
             -n dani --create-namespace \
             -f helm/codex/values.yaml \
@@ -71,6 +107,24 @@ pipeline {
       steps {
         input 'Deploy to staging?'
         sh '''
+          kubectl get secret codex-db-credentials -n staging >/dev/null 2>&1 && \
+          kubectl label secret codex-db-credentials -n staging app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate secret codex-db-credentials -n staging meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=staging --overwrite || true
+          kubectl get pvc codex-db-pvc -n staging >/dev/null 2>&1 && \
+          kubectl label pvc codex-db-pvc -n staging app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate pvc codex-db-pvc -n staging meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=staging --overwrite || true
+          kubectl get service codex-backend -n staging >/dev/null 2>&1 && \
+          kubectl label service codex-backend -n staging app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate service codex-backend -n staging meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=staging --overwrite || true
+          kubectl get service codex-frontend -n staging >/dev/null 2>&1 && \
+          kubectl label service codex-frontend -n staging app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate service codex-frontend -n staging meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=staging --overwrite || true
+          kubectl get service codex-db -n staging >/dev/null 2>&1 && \
+          kubectl label service codex-db -n staging app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate service codex-db -n staging meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=staging --overwrite || true
+          kubectl get deployment codex-backend -n staging >/dev/null 2>&1 && \
+          kubectl label deployment codex-backend -n staging app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate deployment codex-backend -n staging meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=staging --overwrite || true
           helm upgrade --install codex helm/codex \
             -n staging --create-namespace \
             -f helm/codex/values.yaml \
@@ -86,6 +140,24 @@ pipeline {
       steps {
         input 'Deploy to production?'
         sh '''
+          kubectl get secret codex-db-credentials -n prod >/dev/null 2>&1 && \
+          kubectl label secret codex-db-credentials -n prod app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate secret codex-db-credentials -n prod meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=prod --overwrite || true
+          kubectl get pvc codex-db-pvc -n prod >/dev/null 2>&1 && \
+          kubectl label pvc codex-db-pvc -n prod app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate pvc codex-db-pvc -n prod meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=prod --overwrite || true
+          kubectl get service codex-backend -n prod >/dev/null 2>&1 && \
+          kubectl label service codex-backend -n prod app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate service codex-backend -n prod meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=prod --overwrite || true
+          kubectl get service codex-frontend -n prod >/dev/null 2>&1 && \
+          kubectl label service codex-frontend -n prod app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate service codex-frontend -n prod meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=prod --overwrite || true
+          kubectl get service codex-db -n prod >/dev/null 2>&1 && \
+          kubectl label service codex-db -n prod app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate service codex-db -n prod meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=prod --overwrite || true
+          kubectl get deployment codex-backend -n prod >/dev/null 2>&1 && \
+          kubectl label deployment codex-backend -n prod app.kubernetes.io/managed-by=Helm --overwrite && \
+          kubectl annotate deployment codex-backend -n prod meta.helm.sh/release-name=codex meta.helm.sh/release-namespace=prod --overwrite || true
           helm upgrade --install codex helm/codex \
             -n prod --create-namespace \
             -f helm/codex/values.yaml \


### PR DESCRIPTION
## Summary
- Ensure each environment patches the `codex-db-credentials` secret, `codex-db-pvc` claim, `codex-backend` deployment, `codex-backend` service, `codex-frontend` service, and `codex-db` service with Helm ownership labels before running `helm upgrade --install`.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `cd backend && DISABLE_TESTCONTAINERS=true ./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68c09e5d93cc832bb6d0b8ee201ddc84