### PR TITLE
feat: add keycloak resources to helm chart

### DIFF
--- a/helm/codex/templates/keycloak-cr.yaml
+++ b/helm/codex/templates/keycloak-cr.yaml
@@ -1,0 +1,23 @@
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: Keycloak
+metadata:
+  name: my-keycloak
+spec:
+  instances: {{ .Values.keycloak.instances }}
+  db:
+    vendor: postgres
+    host: codex-db.{{ .Release.Namespace }}.svc.cluster.local
+    port: 5432
+    usernameSecret:
+      name: keycloak-db-secret
+      key: username
+    passwordSecret:
+      name: keycloak-db-secret
+      key: password
+  additionalOptions:
+    - name: hostname-strict
+      value: "false"
+    - name: http-enabled
+      value: "true"
+  ingress:
+    enabled: true

--- a/helm/codex/templates/keycloak-db-secret.yaml
+++ b/helm/codex/templates/keycloak-db-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-db-secret
+  labels:
+    app: keycloak
+type: Opaque
+stringData:
+  username: {{ .Values.keycloak.db.user }}
+  password: {{ .Values.keycloak.db.password }}

--- a/helm/codex/templates/keycloak-proxy.yaml
+++ b/helm/codex/templates/keycloak-proxy.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak-proxy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: keycloak-proxy
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/portforward", "services", "endpoints"]
+    verbs: ["get", "list", "watch", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: keycloak-proxy
+subjects:
+  - kind: ServiceAccount
+    name: keycloak-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: keycloak-proxy
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak-proxy
+  labels:
+    app: keycloak-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keycloak-proxy
+  template:
+    metadata:
+      labels:
+        app: keycloak-proxy
+    spec:
+      serviceAccountName: keycloak-proxy
+      containers:
+        - name: kubectl
+          image: bitnami/kubectl:latest
+          command: ["kubectl"]
+          args:
+            - -n
+            - {{ .Release.Namespace }}
+            - port-forward
+            - svc/my-keycloak-service
+            - --address
+            - 0.0.0.0
+            - 8080:8080
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-proxy
+  labels:
+    app: keycloak-proxy
+spec:
+  type: {{ .Values.keycloak.proxy.service.type }}
+  selector:
+    app: keycloak-proxy
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      {{- if .Values.keycloak.proxy.service.nodePort }}
+      nodePort: {{ .Values.keycloak.proxy.service.nodePort }}
+      {{- end }}

--- a/helm/codex/templates/keycloak.yaml
+++ b/helm/codex/templates/keycloak.yaml
@@ -1,0 +1,18 @@
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: KeycloakRealmImport
+metadata:
+  name: codex
+  labels:
+    app: codex
+spec:
+  keycloakCRName: my-keycloak
+  realm:
+    id: codex12
+    realm: codex
+    displayName: codex
+    enabled: true
+    clients:
+      - clientId: codex-frontend
+        publicClient: true
+        redirectUris:
+          - "http://localhost:{{ .Values.keycloak.proxy.service.nodePort }}/*"

--- a/helm/codex/templates/namespace.yaml
+++ b/helm/codex/templates/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace }}

--- a/helm/codex/values-dani.yaml
+++ b/helm/codex/values-dani.yaml
@@ -8,6 +8,11 @@ frontend:
     nodePort: 31080
   env:
     API_URL: "http://localhost:31081"
+    KEYCLOAK_URL: "http://localhost:31001"
 db:
   service:
     nodePort: 31082
+keycloak:
+  proxy:
+    service:
+      nodePort: 31001

--- a/helm/codex/values-prod.yaml
+++ b/helm/codex/values-prod.yaml
@@ -12,3 +12,8 @@ db:
   service:
     type: ClusterIP
     nodePort: null
+keycloak:
+  proxy:
+    service:
+      type: ClusterIP
+      nodePort: null

--- a/helm/codex/values-staging.yaml
+++ b/helm/codex/values-staging.yaml
@@ -12,3 +12,8 @@ db:
   service:
     type: ClusterIP
     nodePort: null
+keycloak:
+  proxy:
+    service:
+      type: ClusterIP
+      nodePort: null

--- a/helm/codex/values.yaml
+++ b/helm/codex/values.yaml
@@ -31,3 +31,13 @@ db:
   service:
     type: NodePort
     nodePort: 30082
+
+keycloak:
+  instances: 2
+  db:
+    user: codex
+    password: codex
+  proxy:
+    service:
+      type: NodePort
+      nodePort: 30001


### PR DESCRIPTION
## Summary
- add Keycloak CR, DB secret, realm import, and proxy templates to Helm chart
- configure keycloak options in values files for dev, prod, staging, and dani environments
- template namespace creation for releases

## Testing
- `helm lint helm/codex`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1dd7ca7b8832b8fcc98c312b727eb