### PR TITLE
Lighten sidebar background to complement toolbar

### DIFF
--- a/frontend/src/app.component.ts
+++ b/frontend/src/app.component.ts
@@ -24,6 +24,11 @@ import { Router } from '@angular/router';
   `,
   styles: [`
     .layout { height: calc(100vh - 64px); }
+    mat-sidenav {
+      background-color: var(--sidebar-bg);
+      color: white;
+      --mat-list-item-label-text-color: white;
+    }
   `]
 })
 export class AppComponent {

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -9,6 +9,8 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <style>
     body,html { margin:0; font-family: Roboto, Arial, sans-serif; }
+    body.light-theme { --sidebar-bg: color-mix(in srgb, #3f51b5 80%, white); }
+    body.dark-theme { --sidebar-bg: color-mix(in srgb, #e91e63 80%, white); }
   </style>
 </head>
 <body>
@@ -22,6 +24,8 @@
       darkLink.toggleAttribute('disabled', !dark);
       lightLink.toggleAttribute('disabled', dark);
     }
+    document.body.classList.toggle('dark-theme', dark);
+    document.body.classList.toggle('light-theme', !dark);
   </script>
   <script src="bundle.js"></script>
 </body>

--- a/frontend/src/top-menu.component.ts
+++ b/frontend/src/top-menu.component.ts
@@ -55,6 +55,8 @@ export class TopMenuComponent {
       darkLink.disabled = !this.dark;
       lightLink.disabled = this.dark;
     }
+    document.body.classList.toggle('dark-theme', this.dark);
+    document.body.classList.toggle('light-theme', !this.dark);
   }
 
   changeLang(l: Lang) {


### PR DESCRIPTION
## Summary
- Style mat-sidenav with a lighter shade of the toolbar color using new CSS variables.
- Toggle `dark-theme` and `light-theme` classes on the body for correct theme-specific sidebar colors.
- Ensure list items and text remain legible on the tinted sidebar.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5ce166d24832b98bd271385cbf43f