### PR TITLE
feat: add top bar menu toggle

### DIFF
--- a/frontend/src/app.component.ts
+++ b/frontend/src/app.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 
 export interface Privilege { id: number; name: string; }
@@ -6,13 +6,21 @@ export interface User { id: number; username: string; privileges: Privilege[]; }
 
 import { AuthService } from './auth.service';
 import { Router } from '@angular/router';
+import { MatSidenav } from '@angular/material/sidenav';
 
 @Component({
   selector: 'app-root',
   template: `
-    <app-top-menu [user]="auth.user" (logout)="logout()" (login)="login()" (account)="account()"></app-top-menu>
+    <app-top-menu
+      [user]="auth.user"
+      (logout)="logout()"
+      (login)="login()"
+      (account)="account()"
+      (menu)="toggleSidenav()"
+      [menuOpened]="sidenav?.opened"
+    ></app-top-menu>
     <mat-sidenav-container *ngIf="auth.user" class="layout">
-      <mat-sidenav [mode]="isMobile ? 'over' : 'side'" [opened]="!isMobile">
+      <mat-sidenav #sidenav [mode]="isMobile ? 'over' : 'side'" [opened]="!isMobile">
         <app-navbar [user]="auth.user"></app-navbar>
       </mat-sidenav>
       <mat-sidenav-content class="content">
@@ -34,6 +42,7 @@ import { Router } from '@angular/router';
 })
 export class AppComponent {
   isMobile = false;
+  @ViewChild('sidenav') sidenav?: MatSidenav;
 
   constructor(
     public auth: AuthService,
@@ -56,5 +65,9 @@ export class AppComponent {
 
   account() {
     this.auth.account();
+  }
+
+  toggleSidenav() {
+    this.sidenav?.toggle();
   }
 }

--- a/frontend/src/top-menu.component.ts
+++ b/frontend/src/top-menu.component.ts
@@ -6,6 +6,14 @@ import { TranslationService, Lang } from './i18n/translation.service';
   selector: 'app-top-menu',
   template: `
     <mat-toolbar color="primary">
+      <button
+        class="menu-btn"
+        mat-icon-button
+        *ngIf="user"
+        (click)="menu.emit()"
+      >
+        <mat-icon>{{ menuOpened ? 'close' : 'menu' }}</mat-icon>
+      </button>
       <span *ngIf="user" class="user">{{ 'WELCOME' | t:{username: user?.username} }}</span>
       <mat-slide-toggle [(ngModel)]="dark" (change)="toggleDark()">{{ 'DARK_MODE' | t }}</mat-slide-toggle>
       <span class="spacer"></span>
@@ -33,13 +41,16 @@ import { TranslationService, Lang } from './i18n/translation.service';
     .spacer { flex: 1 1 auto; }
     .user { margin-right: 1rem; }
     .lang { width: 60px; margin-right: .5rem; }
+    .menu-btn { margin-left: -12px; }
   `]
 })
 export class TopMenuComponent {
   @Input() user?: User;
+  @Input() menuOpened = false;
   @Output() logout = new EventEmitter<void>();
   @Output() login = new EventEmitter<void>();
   @Output() account = new EventEmitter<void>();
+  @Output() menu = new EventEmitter<void>();
   dark = localStorage.getItem('darkMode') === 'true';
   lang: Lang;
 


### PR DESCRIPTION
## Summary
- add menu icon button to top bar to toggle side navigation
- wire top menu button to AppComponent side nav state
- offset top menu button toward edge for tighter alignment

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5da0eb310832ba0fa43b3e3a014fe