### PR TITLE
Make security configuration reactive

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
 //    implementation("org.springframework.boot:spring-boot-starter-jooq")
@@ -33,7 +33,7 @@ dependencies {
     implementation("org.postgresql:r2dbc-postgresql:1.1.1.RELEASE")
     implementation("io.projectreactor:reactor-core:3.8.0")
 
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
+    implementation("org.springdoc:springdoc-openapi-starter-webflux-ui:2.3.0")
 
     implementation("org.jooq:jooq:3.20.0")
     implementation("org.jooq:jooq-jpa-extensions:3.20.0")

--- a/backend/src/main/kotlin/com/example/codex/config/JwtAuthConverter.kt
+++ b/backend/src/main/kotlin/com/example/codex/config/JwtAuthConverter.kt
@@ -1,36 +1,29 @@
 package com.example.codex.config
 
-import com.example.codex.service.UserService
+import com.example.codex.domain.User
 import org.slf4j.LoggerFactory
 import org.springframework.core.convert.converter.Converter
 import org.springframework.security.authentication.AbstractAuthenticationToken
 import org.springframework.security.core.authority.SimpleGrantedAuthority
-import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 import org.springframework.stereotype.Component
+import reactor.core.publisher.Mono
 
 @Component
 class JwtAuthConverter(
-    private val userService: UserService,
-) : Converter<Jwt, AbstractAuthenticationToken> {
+    private val userValidator: UserValidator,
+) : Converter<Jwt, Mono<AbstractAuthenticationToken>> {
     companion object {
         private val logger = LoggerFactory.getLogger(JwtAuthConverter::class.java)
     }
 
-    override fun convert(jwt: Jwt): AbstractAuthenticationToken {
-        val externalId = jwt.subject
-        logger.debug("Authenticating JWT for subject {}", externalId)
-
-        val user = userService.findByExternalId(externalId).block()
-        if (user == null) {
-            logger.warn("User not found for subject {}", externalId)
-            throw UsernameNotFoundException("No user: $externalId")
+    override fun convert(jwt: Jwt): Mono<AbstractAuthenticationToken> =
+        userValidator.ensureUser(jwt).map { user ->
+            val authorities = buildAuthorities(user)
+            logger.debug("Authorities for subject {}: {}", jwt.subject, authorities)
+            JwtAuthenticationToken(jwt, authorities, jwt.subject)
         }
 
-        val authorities = user.privileges.map { SimpleGrantedAuthority(it.name) }
-        logger.debug("Authorities for subject {}: {}", externalId, authorities)
-
-        return JwtAuthenticationToken(jwt, authorities, externalId)
-    }
+    private fun buildAuthorities(user: User) = user.privileges.map { SimpleGrantedAuthority(it.name) }
 }

--- a/backend/src/main/kotlin/com/example/codex/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/com/example/codex/config/SecurityConfig.kt
@@ -1,36 +1,33 @@
 package com.example.codex.config
 
+import com.example.codex.domain.User
 import com.example.codex.service.UserService
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
-import org.springframework.security.config.annotation.web.builders.HttpSecurity
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
-import org.springframework.security.config.http.SessionCreationPolicy
-import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator
-import org.springframework.security.oauth2.core.OAuth2Error
-import org.springframework.security.oauth2.core.OAuth2TokenValidator
-import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult
+import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
+import org.springframework.security.config.web.server.ServerHttpSecurity
+import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.security.oauth2.jwt.Jwt
-import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.oauth2.jwt.JwtValidators
-import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
-import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.oauth2.jwt.NimbusReactiveJwtDecoder
+import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder
+import org.springframework.security.web.server.SecurityWebFilterChain
 import org.springframework.stereotype.Component
 import org.springframework.web.cors.CorsConfiguration
 import reactor.core.publisher.Mono
 
 
 @Configuration
-@EnableWebSecurity
-@EnableMethodSecurity
+@EnableWebFluxSecurity
+@EnableReactiveMethodSecurity
 class SecurityConfig(
-    private val userValidator: UserValidator,
+    private val jwtAuthConverter: JwtAuthConverter,
     @Value("\${frontendUrl}")
     private val frontendUrl: String,
     @Value("\${spring.security.oauth2.resourceserver.jwt.jwk-set-uri}")
-    private val jwkSetUri: String?
+    private val jwkSetUri: String
 ) {
     companion object {
         private val AUTH_WHITELIST =
@@ -43,46 +40,12 @@ class SecurityConfig(
     }
 
 
-    private fun jwtDecoder(): JwtDecoder {
-        val jwtDecoder: NimbusJwtDecoder = NimbusJwtDecoder.withJwkSetUri(jwkSetUri).build()
-        println("jwkSetUri $jwkSetUri")
-        val withIssuer: OAuth2TokenValidator<Jwt> = JwtValidators.createDefault()
-        val withAudience: OAuth2TokenValidator<Jwt> = DelegatingOAuth2TokenValidator(withIssuer, userValidator)
-
-        jwtDecoder.setJwtValidator(withAudience)
-
-        return jwtDecoder
-    }
-
-    @Component
-    class UserValidator(private val userService: UserService) : OAuth2TokenValidator<Jwt> {
-
-        private fun error() = OAuth2Error("ERR-SAVE", "Error while saving user id", null)
-
-        override fun validate(jwt: Jwt): OAuth2TokenValidatorResult = try {
-            println("validate")
-            userService.findByExternalId(jwt.subject).flatMap {
-                println("value: $it")
-                if (it == null) {
-                    userService.register(jwt.getClaim("preferred_username"), "12345678", jwt.subject)
-                } else {
-                    Mono.empty()
-                }
-            }.onErrorMap { error(it) }.block()
-            OAuth2TokenValidatorResult.success()
-        } catch (e: Exception) {
-            OAuth2TokenValidatorResult.failure(error())
-        }
-    }
-
     @Bean
-    fun securityFilterChain(
-        http: HttpSecurity,
-    ): SecurityFilterChain {
+    fun securityFilterChain(http: ServerHttpSecurity): SecurityWebFilterChain =
         http
             .csrf { it.disable() }
-            .cors {
-                it.configurationSource { request ->
+            .cors { cors ->
+                cors.configurationSource {
                     CorsConfiguration().apply {
                         allowedOrigins = listOf(frontendUrl)
                         allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
@@ -91,21 +54,46 @@ class SecurityConfig(
                     }
                 }
             }
-            .sessionManagement {
-                it.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-            }.authorizeHttpRequests { authz ->
-                authz
-                    .requestMatchers(*AUTH_WHITELIST)
+            .authorizeExchange { exchanges ->
+                exchanges
+                    .pathMatchers(*AUTH_WHITELIST)
                     .permitAll()
-                    .anyRequest()
+                    .anyExchange()
                     .authenticated()
             }
-        http.oauth2ResourceServer { oauth2 ->
-            oauth2.jwt {
-                it.decoder(jwtDecoder())
+            .oauth2ResourceServer { oauth2 ->
+                oauth2.jwt { jwt ->
+                    jwt.jwtAuthenticationConverter(jwtAuthConverter)
+                    jwt.jwtDecoder(jwtDecoder())
+                }
             }
-        }
-        println("security end")
-        return http.build()
+            .build()
+
+    @Bean
+    fun jwtDecoder(): ReactiveJwtDecoder {
+        val jwtDecoder = NimbusReactiveJwtDecoder.withJwkSetUri(jwkSetUri).build()
+        jwtDecoder.setJwtValidator(JwtValidators.createDefault())
+        return jwtDecoder
+    }
+}
+
+@Component
+class UserValidator(private val userService: UserService) {
+    fun ensureUser(jwt: Jwt): Mono<User> {
+        val externalId = jwt.subject
+        val username = jwt.getClaimAsString("preferred_username")
+
+        return userService.findByExternalId(externalId)
+            .switchIfEmpty(
+                userService.register(username, "12345678", externalId)
+                    .flatMap { registered ->
+                        if (registered) {
+                            userService.findByExternalId(externalId)
+                        } else {
+                            Mono.empty()
+                        }
+                    },
+            )
+            .switchIfEmpty(Mono.error(UsernameNotFoundException("No user: $externalId")))
     }
 }


### PR DESCRIPTION
## Summary
- switch backend to reactive security/webflux dependencies
- replace servlet SecurityFilterChain with reactive configuration and reactive JWT authentication converter
- add reactive user validation to ensure users exist before building JWT authentication

## Testing
- `DISABLE_TESTCONTAINERS=true ./gradlew test --no-daemon --console=plain --stacktrace --info` *(fails: database authentication failed during Spring context initialization)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cd543ff5c832ba466c1150ae3082b)