### PR TITLE
Fix controller tests

### DIFF
--- a/backend/src/main/kotlin/com/example/codex/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/com/example/codex/config/SecurityConfig.kt
@@ -43,7 +43,8 @@ class SecurityConfig(
     }
 
 
-    private fun jwtDecoder(): JwtDecoder {
+    @Bean
+    fun jwtDecoder(): JwtDecoder {
         val jwtDecoder: NimbusJwtDecoder = NimbusJwtDecoder.withJwkSetUri(jwkSetUri).build()
         println("jwkSetUri $jwkSetUri")
         val withIssuer: OAuth2TokenValidator<Jwt> = JwtValidators.createDefault()
@@ -78,6 +79,7 @@ class SecurityConfig(
     @Bean
     fun securityFilterChain(
         http: HttpSecurity,
+        jwtDecoder: JwtDecoder,
     ): SecurityFilterChain {
         http
             .csrf { it.disable() }
@@ -99,10 +101,10 @@ class SecurityConfig(
                     .permitAll()
                     .anyRequest()
                     .authenticated()
-            }
+        }
         http.oauth2ResourceServer { oauth2 ->
             oauth2.jwt {
-                it.decoder(jwtDecoder())
+                it.decoder(jwtDecoder)
             }
         }
         println("security end")

--- a/backend/src/main/kotlin/com/example/codex/controller/PrivilegeController.kt
+++ b/backend/src/main/kotlin/com/example/codex/controller/PrivilegeController.kt
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 
 @RestController
 @RequestMapping("/api/privileges")
@@ -15,5 +16,8 @@ class PrivilegeController(
     private val userService: UserService,
 ) {
     @GetMapping
-    fun list(): Flux<Privilege> = userService.allPrivileges()
+    fun list(): Mono<List<Privilege>> =
+        userService
+            .allPrivileges()
+            .collectList()
 }

--- a/backend/src/test/kotlin/com/example/codex/controller/PrivilegeControllerIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/example/codex/controller/PrivilegeControllerIntegrationTest.kt
@@ -6,9 +6,12 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.request
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt
 import java.util.UUID
@@ -42,16 +45,23 @@ class PrivilegeControllerIntegrationTest @Autowired constructor(
             .andExpect(status().isOk)
 
         // Call the secured endpoint with a mocked JWT user
-        mockMvc
-            .perform(
-                get("/api/privileges").with(
-                    jwt().jwt {
-                        it.subject(externalId)                   // -> jwt.subject
-                        it.claim("preferred_username", username) // extra claim if you need it
-                    }
+        val mvcResult =
+            mockMvc
+                .perform(
+                    get("/api/privileges").with(
+                        jwt().jwt {
+                            it.subject(externalId)                   // -> jwt.subject
+                            it.claim("preferred_username", username) // extra claim if you need it
+                        }
+                    )
                 )
-            )
+                .andExpect(request().asyncStarted())
+                .andReturn()
+
+        mockMvc
+            .perform(asyncDispatch(mvcResult))
             .andExpect(status().isOk)
+            .andDo(print())
             // if /api/privileges returns a list of objects like [{ "name": "dashboard" }, ...]
             .andExpect(jsonPath("$[?(@.name == 'dashboard')]").exists())
             .andExpect(jsonPath("$[?(@.name == 'users')]").exists())


### PR DESCRIPTION
## Summary
- expose the JWT decoder as a bean and inject it into the security filter chain so tests can mock authentication
- aggregate privilege responses and update the privilege controller test to await async responses

## Testing
- DISABLE_TESTCONTAINERS=true SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5432/codex SPRING_DATASOURCE_USERNAME=codex SPRING_DATASOURCE_PASSWORD=codex ./gradlew test --tests "com.example.codex.controller.*" --no-daemon --console=plain


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ce87b0988832b879e5bf37abe9c4e)