### PR TITLE
Make security config reactive

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
 //    implementation("org.springframework.boot:spring-boot-starter-jooq")
@@ -33,7 +33,7 @@ dependencies {
     implementation("org.postgresql:r2dbc-postgresql:1.1.1.RELEASE")
     implementation("io.projectreactor:reactor-core:3.8.0")
 
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
+    implementation("org.springdoc:springdoc-openapi-starter-webflux-ui:2.3.0")
 
     implementation("org.jooq:jooq:3.20.0")
     implementation("org.jooq:jooq-jpa-extensions:3.20.0")

--- a/backend/src/main/kotlin/com/example/codex/config/JwtAuthConverter.kt
+++ b/backend/src/main/kotlin/com/example/codex/config/JwtAuthConverter.kt
@@ -1,36 +1,29 @@
 package com.example.codex.config
 
-import com.example.codex.service.UserService
+import com.example.codex.domain.User
 import org.slf4j.LoggerFactory
 import org.springframework.core.convert.converter.Converter
 import org.springframework.security.authentication.AbstractAuthenticationToken
 import org.springframework.security.core.authority.SimpleGrantedAuthority
-import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 import org.springframework.stereotype.Component
+import reactor.core.publisher.Mono
 
 @Component
 class JwtAuthConverter(
-    private val userService: UserService,
-) : Converter<Jwt, AbstractAuthenticationToken> {
+    private val userValidator: SecurityConfig.UserValidator,
+) : Converter<Jwt, Mono<AbstractAuthenticationToken>> {
     companion object {
         private val logger = LoggerFactory.getLogger(JwtAuthConverter::class.java)
     }
 
-    override fun convert(jwt: Jwt): AbstractAuthenticationToken {
-        val externalId = jwt.subject
-        logger.debug("Authenticating JWT for subject {}", externalId)
-
-        val user = userService.findByExternalId(externalId).block()
-        if (user == null) {
-            logger.warn("User not found for subject {}", externalId)
-            throw UsernameNotFoundException("No user: $externalId")
+    override fun convert(jwt: Jwt): Mono<AbstractAuthenticationToken> =
+        userValidator.ensureUser(jwt).map { user ->
+            val authorities = buildAuthorities(user)
+            logger.debug("Authorities for subject {}: {}", jwt.subject, authorities)
+            JwtAuthenticationToken(jwt, authorities, jwt.subject)
         }
 
-        val authorities = user.privileges.map { SimpleGrantedAuthority(it.name) }
-        logger.debug("Authorities for subject {}: {}", externalId, authorities)
-
-        return JwtAuthenticationToken(jwt, authorities, externalId)
-    }
+    private fun buildAuthorities(user: User) = user.privileges.map { SimpleGrantedAuthority(it.name) }
 }

--- a/backend/src/main/kotlin/com/example/codex/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/com/example/codex/config/SecurityConfig.kt
@@ -4,33 +4,35 @@ import com.example.codex.service.UserService
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
-import org.springframework.security.config.annotation.web.builders.HttpSecurity
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
-import org.springframework.security.config.http.SessionCreationPolicy
-import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator
+import org.springframework.core.convert.converter.Converter
+import org.springframework.security.authentication.AbstractAuthenticationToken
+import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
+import org.springframework.security.config.web.server.ServerHttpSecurity
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException
 import org.springframework.security.oauth2.core.OAuth2Error
-import org.springframework.security.oauth2.core.OAuth2TokenValidator
-import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult
 import org.springframework.security.oauth2.jwt.Jwt
-import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.oauth2.jwt.JwtValidators
-import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
-import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.oauth2.jwt.NimbusReactiveJwtDecoder
+import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter
+import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtAuthenticationConverterAdapter
+import org.springframework.security.web.server.SecurityWebFilterChain
+import org.springframework.security.web.server.context.NoOpServerSecurityContextRepository
 import org.springframework.stereotype.Component
 import org.springframework.web.cors.CorsConfiguration
 import reactor.core.publisher.Mono
 
 
 @Configuration
-@EnableWebSecurity
-@EnableMethodSecurity
+@EnableWebFluxSecurity
+@EnableReactiveMethodSecurity
 class SecurityConfig(
     private val userValidator: UserValidator,
     @Value("\${frontendUrl}")
     private val frontendUrl: String,
     @Value("\${spring.security.oauth2.resourceserver.jwt.jwk-set-uri}")
-    private val jwkSetUri: String?
+    private val jwkSetUri: String
 ) {
     companion object {
         private val AUTH_WHITELIST =
@@ -44,47 +46,30 @@ class SecurityConfig(
 
 
     @Bean
-    fun jwtDecoder(): JwtDecoder {
-        val jwtDecoder: NimbusJwtDecoder = NimbusJwtDecoder.withJwkSetUri(jwkSetUri).build()
-        println("jwkSetUri $jwkSetUri")
-        val withIssuer: OAuth2TokenValidator<Jwt> = JwtValidators.createDefault()
-        val withAudience: OAuth2TokenValidator<Jwt> = DelegatingOAuth2TokenValidator(withIssuer, userValidator)
-
-        jwtDecoder.setJwtValidator(withAudience)
-
+    fun jwtDecoder(): ReactiveJwtDecoder {
+        val jwtDecoder = NimbusReactiveJwtDecoder.withJwkSetUri(jwkSetUri).build()
+        jwtDecoder.setJwtValidator(JwtValidators.createDefault())
         return jwtDecoder
     }
 
-    @Component
-    class UserValidator(private val userService: UserService) : OAuth2TokenValidator<Jwt> {
-
-        private fun error() = OAuth2Error("ERR-SAVE", "Error while saving user id", null)
-
-        override fun validate(jwt: Jwt): OAuth2TokenValidatorResult = try {
-            println("validate")
-            userService.findByExternalId(jwt.subject).flatMap {
-                println("value: $it")
-                if (it == null) {
-                    userService.register(jwt.getClaim("preferred_username"), "12345678", jwt.subject)
-                } else {
-                    Mono.empty()
-                }
-            }.onErrorMap { error(it) }.block()
-            OAuth2TokenValidatorResult.success()
-        } catch (e: Exception) {
-            OAuth2TokenValidatorResult.failure(error())
+    @Bean
+    fun jwtAuthenticationConverter(): Converter<Jwt, Mono<out AbstractAuthenticationToken>> {
+        val delegate = ReactiveJwtAuthenticationConverterAdapter(JwtAuthenticationConverter())
+        return Converter { jwt ->
+            userValidator.validate(jwt).then(delegate.convert(jwt) ?: Mono.empty())
         }
     }
 
     @Bean
     fun securityFilterChain(
-        http: HttpSecurity,
-        jwtDecoder: JwtDecoder,
-    ): SecurityFilterChain {
-        http
+        http: ServerHttpSecurity,
+        jwtDecoder: ReactiveJwtDecoder,
+        jwtAuthenticationConverter: Converter<Jwt, Mono<out AbstractAuthenticationToken>>,
+    ): SecurityWebFilterChain {
+        return http
             .csrf { it.disable() }
             .cors {
-                it.configurationSource { request ->
+                it.configurationSource { _ ->
                     CorsConfiguration().apply {
                         allowedOrigins = listOf(frontendUrl)
                         allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
@@ -93,21 +78,41 @@ class SecurityConfig(
                     }
                 }
             }
-            .sessionManagement {
-                it.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-            }.authorizeHttpRequests { authz ->
+            .securityContextRepository(NoOpServerSecurityContextRepository.getInstance())
+            .authorizeExchange { authz ->
                 authz
-                    .requestMatchers(*AUTH_WHITELIST)
+                    .pathMatchers(*AUTH_WHITELIST)
                     .permitAll()
-                    .anyRequest()
+                    .anyExchange()
                     .authenticated()
-        }
-        http.oauth2ResourceServer { oauth2 ->
-            oauth2.jwt {
-                it.decoder(jwtDecoder)
             }
-        }
-        println("security end")
-        return http.build()
+            .oauth2ResourceServer { oauth2 ->
+                oauth2.jwt { jwt ->
+                    jwt.jwtDecoder(jwtDecoder)
+                    jwt.jwtAuthenticationConverter(jwtAuthenticationConverter)
+                }
+            }
+            .build()
+    }
+
+    @Component
+    class UserValidator(private val userService: UserService) {
+
+        private fun error(cause: Throwable? = null) =
+            OAuth2AuthenticationException(OAuth2Error("ERR-SAVE", "Error while saving user id", null), cause)
+
+        fun validate(jwt: Jwt): Mono<Void> =
+            userService.findByExternalId(jwt.subject)
+                .switchIfEmpty(
+                    userService.register(jwt.getClaim("preferred_username"), "12345678", jwt.subject)
+                        .flatMap { created ->
+                            if (created) {
+                                Mono.empty()
+                            } else {
+                                Mono.error(error())
+                            }
+                        },
+                ).then()
+                .onErrorMap { error(it) }
     }
 }

--- a/backend/src/main/kotlin/com/example/codex/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/com/example/codex/config/SecurityConfig.kt
@@ -1,5 +1,6 @@
 package com.example.codex.config
 
+import com.example.codex.domain.User
 import com.example.codex.service.UserService
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
@@ -9,6 +10,7 @@ import org.springframework.security.authentication.AbstractAuthenticationToken
 import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
 import org.springframework.security.config.web.server.ServerHttpSecurity
+import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException
 import org.springframework.security.oauth2.core.OAuth2Error
 import org.springframework.security.oauth2.jwt.Jwt
@@ -55,10 +57,15 @@ class SecurityConfig(
     @Bean
     fun jwtAuthenticationConverter(): Converter<Jwt, Mono<out AbstractAuthenticationToken>> {
         val delegate = ReactiveJwtAuthenticationConverterAdapter(JwtAuthenticationConverter())
-        return Converter { jwt ->
-            userValidator.validate(jwt).then(delegate.convert(jwt) ?: Mono.empty())
+
+        return object : Converter<Jwt, Mono<out AbstractAuthenticationToken>> {
+            override fun convert(jwt: Jwt): Mono<out AbstractAuthenticationToken> {
+                return userValidator.ensureUser(jwt)
+                    .then(delegate.convert(jwt) ?: Mono.empty())
+            }
         }
     }
+
 
     @Bean
     fun securityFilterChain(
@@ -98,21 +105,22 @@ class SecurityConfig(
     @Component
     class UserValidator(private val userService: UserService) {
 
-        private fun error(cause: Throwable? = null) =
-            OAuth2AuthenticationException(OAuth2Error("ERR-SAVE", "Error while saving user id", null), cause)
+        fun ensureUser(jwt: Jwt): Mono<User> {
+            val externalId = jwt.subject
+            val username = jwt.getClaimAsString("preferred_username")
 
-        fun validate(jwt: Jwt): Mono<Void> =
-            userService.findByExternalId(jwt.subject)
+            return userService.findByExternalId(externalId)
                 .switchIfEmpty(
-                    userService.register(jwt.getClaim("preferred_username"), "12345678", jwt.subject)
-                        .flatMap { created ->
-                            if (created) {
-                                Mono.empty()
+                    userService.register(username, "12345678", externalId)
+                        .flatMap { registered ->
+                            if (registered) {
+                                userService.findByExternalId(externalId)
                             } else {
-                                Mono.error(error())
+                                Mono.empty()
                             }
                         },
-                ).then()
-                .onErrorMap { error(it) }
+                )
+                .switchIfEmpty(Mono.error(UsernameNotFoundException("No user: $externalId")))
+        }
     }
 }


### PR DESCRIPTION
## Summary
- update backend dependencies to use WebFlux and the WebFlux OpenAPI starter
- replace servlet-based security with a reactive WebFlux security filter chain and JWT authentication converter
- refresh the user validation logic to run reactively during JWT authentication

## Testing
- DISABLE_TESTCONTAINERS=true ./gradlew test --no-daemon --console=plain *(fails: PostgreSQL/Liquibase connection not available for integration tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cf2acbfa8832bb83554a5081dbeac)