### PR TITLE
Use WebTestClient in privilege controller integration test

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 
 group = "com.example"
 version = "0.0.1-SNAPSHOT"
-java.sourceCompatibility = JavaVersion.VERSION_17
+java.sourceCompatibility = JavaVersion.VERSION_21
 
 repositories {
     mavenCentral()
@@ -46,6 +46,9 @@ dependencies {
     implementation("org.liquibase:liquibase-core")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation("io.github.oshai:kotlin-logging-jvm:5.1.0")
+    testImplementation("io.mockk:mockk:1.14.6")
+    testImplementation("com.ninja-squad:springmockk:4.0.2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.testcontainers:r2dbc")
@@ -130,7 +133,7 @@ jooq {
 
 tasks.withType<KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_17)
+        jvmTarget.set(JvmTarget.JVM_21)
     }
 }
 

--- a/backend/src/main/kotlin/com/example/codex/config/Beans.kt
+++ b/backend/src/main/kotlin/com/example/codex/config/Beans.kt
@@ -13,9 +13,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.transaction.ReactiveTransactionManager
 
-
 @Configuration
-class Beans() {
+class Beans {
     @Bean
     fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
 
@@ -30,7 +29,6 @@ class Beans() {
     }
 
     @Bean
-    fun reactiveTransactionManager(connectionFactory: ConnectionFactory): ReactiveTransactionManager {
-        return R2dbcTransactionManager(connectionFactory)
-    }
+    fun reactiveTransactionManager(connectionFactory: ConnectionFactory): ReactiveTransactionManager =
+        R2dbcTransactionManager(connectionFactory)
 }

--- a/backend/src/main/kotlin/com/example/codex/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/com/example/codex/config/SecurityConfig.kt
@@ -2,9 +2,11 @@ package com.example.codex.config
 
 import com.example.codex.domain.User
 import com.example.codex.service.UserService
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 import org.springframework.core.convert.converter.Converter
 import org.springframework.security.authentication.AbstractAuthenticationToken
 import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity
@@ -25,7 +27,6 @@ import org.springframework.stereotype.Component
 import org.springframework.web.cors.CorsConfiguration
 import reactor.core.publisher.Mono
 
-
 @Configuration
 @EnableWebFluxSecurity
 @EnableReactiveMethodSecurity
@@ -34,18 +35,17 @@ class SecurityConfig(
     @Value("\${frontendUrl}")
     private val frontendUrl: String,
     @Value("\${spring.security.oauth2.resourceserver.jwt.jwk-set-uri}")
-    private val jwkSetUri: String
+    private val jwkSetUri: String,
 ) {
     companion object {
         private val AUTH_WHITELIST =
             arrayOf(
-                "/api/users/register",
+                "/api/users/register/**",
                 "/v3/api-docs/**",
                 "/swagger-ui.html",
                 "/swagger-ui/**",
             )
     }
-
 
     @Bean
     fun jwtDecoder(): ReactiveJwtDecoder {
@@ -59,21 +59,20 @@ class SecurityConfig(
         val delegate = ReactiveJwtAuthenticationConverterAdapter(JwtAuthenticationConverter())
 
         return object : Converter<Jwt, Mono<out AbstractAuthenticationToken>> {
-            override fun convert(jwt: Jwt): Mono<out AbstractAuthenticationToken> {
-                return userValidator.ensureUser(jwt)
+            override fun convert(jwt: Jwt): Mono<out AbstractAuthenticationToken> =
+                userValidator
+                    .ensureUser(jwt)
                     .then(delegate.convert(jwt) ?: Mono.empty())
-            }
         }
     }
-
 
     @Bean
     fun securityFilterChain(
         http: ServerHttpSecurity,
         jwtDecoder: ReactiveJwtDecoder,
         jwtAuthenticationConverter: Converter<Jwt, Mono<out AbstractAuthenticationToken>>,
-    ): SecurityWebFilterChain {
-        return http
+    ): SecurityWebFilterChain =
+        http
             .csrf { it.disable() }
             .cors {
                 it.configurationSource { _ ->
@@ -84,34 +83,33 @@ class SecurityConfig(
                         allowCredentials = true
                     }
                 }
-            }
-            .securityContextRepository(NoOpServerSecurityContextRepository.getInstance())
+            }.securityContextRepository(NoOpServerSecurityContextRepository.getInstance())
             .authorizeExchange { authz ->
                 authz
                     .pathMatchers(*AUTH_WHITELIST)
                     .permitAll()
                     .anyExchange()
                     .authenticated()
-            }
-            .oauth2ResourceServer { oauth2 ->
+            }.oauth2ResourceServer { oauth2 ->
                 oauth2.jwt { jwt ->
                     jwt.jwtDecoder(jwtDecoder)
                     jwt.jwtAuthenticationConverter(jwtAuthenticationConverter)
                 }
-            }
-            .build()
-    }
+            }.build()
 
     @Component
-    class UserValidator(private val userService: UserService) {
-
+    class UserValidator(
+        private val userService: UserService,
+    ) {
         fun ensureUser(jwt: Jwt): Mono<User> {
             val externalId = jwt.subject
             val username = jwt.getClaimAsString("preferred_username")
 
-            return userService.findByExternalId(externalId)
+            return userService
+                .findByExternalId(externalId)
                 .switchIfEmpty(
-                    userService.register(username, "12345678", externalId)
+                    userService
+                        .register(username, "12345678", externalId)
                         .flatMap { registered ->
                             if (registered) {
                                 userService.findByExternalId(externalId)
@@ -119,8 +117,7 @@ class SecurityConfig(
                                 Mono.empty()
                             }
                         },
-                )
-                .switchIfEmpty(Mono.error(UsernameNotFoundException("No user: $externalId")))
+                ).switchIfEmpty(Mono.error(UsernameNotFoundException("No user: $externalId")))
         }
     }
 }

--- a/backend/src/main/kotlin/com/example/codex/controller/UserController.kt
+++ b/backend/src/main/kotlin/com/example/codex/controller/UserController.kt
@@ -34,28 +34,19 @@ class UserController(
         @RequestParam username: String,
         @RequestParam password: String,
         @RequestParam externalId: String,
-    ): Mono<Boolean> {
-        return userService.register(username, password, externalId)
-    }
+    ): Mono<Boolean> = userService.register(username, password, externalId)
 
     @DeleteMapping("/{id}")
     fun delete(
         @PathVariable id: Long,
-    ): Mono<Int> {
-        return userService.delete(id)
-    }
+    ): Mono<Int> = userService.delete(id)
 
     @GetMapping("/me")
-    fun me(principal: java.security.Principal): Mono<User> {
-        println("principal: ${principal.name}")
-        return userService.findByExternalId(principal.name).log()
-    }
+    fun me(principal: java.security.Principal): Mono<User> = userService.findByExternalId(principal.name).log()
 
     @PostMapping("/{id}/privileges")
     fun updatePrivileges(
         @PathVariable id: Long,
         @RequestBody privilegeIds: List<Long>,
-    ): Mono<Void> {
-        return userService.updatePrivileges(id, privilegeIds)
-    }
+    ): Mono<Void> = userService.updatePrivileges(id, privilegeIds)
 }

--- a/backend/src/main/kotlin/com/example/codex/repository/CrudRepository.kt
+++ b/backend/src/main/kotlin/com/example/codex/repository/CrudRepository.kt
@@ -34,35 +34,35 @@ interface CrudRepository<TABLE : Table<out Record>, POJO : Any, KEY> {
             .map { it.into(type) }
 
     fun insert(pojo: POJO): Mono<POJO> =
-        dslContext.newRecord(table, pojo)
+        dslContext
+            .newRecord(table, pojo)
             .let { record ->
-                dslContext.insertInto(table)
+                dslContext
+                    .insertInto(table)
                     .set(record)
                     .returning()
-            }
-            .let { Mono.from(it) }
+            }.let { Mono.from(it) }
             .map { it.into(type) }
 
     fun save(pojo: POJO): Mono<POJO> =
-        dslContext.newRecord(table, pojo)
+        dslContext
+            .newRecord(table, pojo)
             .let { record ->
                 dslContext
                     .insertInto(table)
                     .set(record)
                     .onConflict(
                         table.field("id", keyType),
-                    )
-                    .doUpdate()
+                    ).doUpdate()
                     .setNonConflictingKeyToExcluded()
                     .returning()
-            }
-            .let { Mono.from(it) }
+            }.let { Mono.from(it) }
             .map { it.into(type) }
 
     fun saveAll(
         pojos: Flux<POJO>,
         batchSize: Int = 500,
-        conflictFields: List<Field<*>> = listOf(table.field("id", keyType)!!)
+        conflictFields: List<Field<*>> = listOf(table.field("id", keyType)!!),
     ): Flux<POJO> =
         pojos
             .buffer(batchSize)
@@ -72,15 +72,17 @@ interface CrudRepository<TABLE : Table<out Record>, POJO : Any, KEY> {
                 val insert = dslContext.insertInto(table).set(records)
                 val nonConflictInsertColumns =
                     table.fields().filter { f -> f.name !in conflictFields.plus(keyField).map { it.name } }
-                val upsert = if (nonConflictInsertColumns.isEmpty()) {
-                    insert
-                        .onConflict()
-                        .doNothing()
-                } else {
-                    insert.onConflict(*conflictFields.plus(keyField).toTypedArray())
-                        .doUpdate()
-                        .setNonConflictingKeyToExcluded()
-                }
+                val upsert =
+                    if (nonConflictInsertColumns.isEmpty()) {
+                        insert
+                            .onConflict()
+                            .doNothing()
+                    } else {
+                        insert
+                            .onConflict(*conflictFields.plus(keyField).toTypedArray())
+                            .doUpdate()
+                            .setNonConflictingKeyToExcluded()
+                    }
                 Flux.from(upsert.returning()).map { it.into(type) }
             }
 
@@ -101,6 +103,6 @@ interface CrudRepository<TABLE : Table<out Record>, POJO : Any, KEY> {
         Mono.from(
             dslContext
                 .deleteFrom(table)
-                .where(table.field("id", keyType)!!.eq(id))
+                .where(table.field("id", keyType)!!.eq(id)),
         )
 }

--- a/backend/src/main/kotlin/com/example/codex/repository/UserPrivilegeRepository.kt
+++ b/backend/src/main/kotlin/com/example/codex/repository/UserPrivilegeRepository.kt
@@ -1,6 +1,5 @@
 package com.example.codex.repository
 
-
 import com.example.codex.jooq.tables.pojos.UserPrivilege
 import com.example.codex.jooq.tables.references.USER_PRIVILEGE
 import org.jooq.DSLContext
@@ -21,8 +20,6 @@ class UserPrivilegeRepository(
 
     fun saveAll(
         pojos: Flux<UserPrivilege>,
-        batchSize: Int = 500
-    ): Flux<UserPrivilege> {
-        return super.saveAll(pojos, batchSize, listOf(USER_PRIVILEGE.USER_ID, USER_PRIVILEGE.PRIVILEGE_ID))
-    }
+        batchSize: Int = 500,
+    ): Flux<UserPrivilege> = super.saveAll(pojos, batchSize, listOf(USER_PRIVILEGE.USER_ID, USER_PRIVILEGE.PRIVILEGE_ID))
 }

--- a/backend/src/main/kotlin/com/example/codex/repository/UserRepository.kt
+++ b/backend/src/main/kotlin/com/example/codex/repository/UserRepository.kt
@@ -12,11 +12,13 @@ import org.jooq.Record
 import org.jooq.SelectJoinStep
 import org.jooq.impl.DSL
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import com.example.codex.jooq.tables.Users as UsersTable
 
 @Repository
+@Transactional
 class UserRepository(
     override val dslContext: DSLContext,
 ) : CrudRepository<UsersTable, User, Long> {
@@ -52,17 +54,13 @@ class UserRepository(
         password: String,
         externalId: String,
     ) = dslContext
-        .also { println("userName :$username password:$password externalId:$externalId") }
-            .insertInto(USERS)
-            .set(USERS.USERNAME, username)
-            .set(USERS.PASSWORD, password)
-            .set(USERS.EXTERNAL_ID, externalId)
-            .returning(*USERS.fields())
-            .let { Mono.from(it) }
-            .map {
-                println("fetched: $it")
-                it.into(Users::class.java) }
-
+        .insertInto(USERS)
+        .set(USERS.USERNAME, username)
+        .set(USERS.PASSWORD, password)
+        .set(USERS.EXTERNAL_ID, externalId)
+        .returning(*USERS.fields())
+        .let { Mono.from(it) }
+        .map { it.into(Users::class.java) }
 
     fun softDelete(id: Long) =
         dslContext
@@ -72,11 +70,11 @@ class UserRepository(
             .let { Mono.from(it) }
 
     fun findByUsername(username: String) =
-        Mono.from(
-            baseUserQuery()
-                .where(USERS.USERNAME.eq(username).and(USERS.DELETED.eq(false)))
-        ).map { it.into(User::class.java) }
-
+        Mono
+            .from(
+                baseUserQuery()
+                    .where(USERS.USERNAME.eq(username).and(USERS.DELETED.eq(false))),
+            ).map { it.into(User::class.java) }
 
     fun findByExternalId(externalId: String): Mono<User> =
         baseUserQuery()
@@ -88,31 +86,32 @@ class UserRepository(
         userId: Long,
         privilegeId: Long,
     ) = dslContext
-            .insertInto(USER_PRIVILEGE)
-            .set(USER_PRIVILEGE.USER_ID, userId)
-            .set(USER_PRIVILEGE.PRIVILEGE_ID, privilegeId)
-            .let { Mono.from(it) }
+        .insertInto(USER_PRIVILEGE)
+        .set(USER_PRIVILEGE.USER_ID, userId)
+        .set(USER_PRIVILEGE.PRIVILEGE_ID, privilegeId)
+        .let { Mono.from(it) }
 
     fun updateUserPrivileges(
         userId: Long,
         privilegeIds: List<Long>,
     ): Mono<Void> =
-        Mono.from(
-            dslContext.deleteFrom(USER_PRIVILEGE)
-                .where(USER_PRIVILEGE.USER_ID.eq(userId))
-        )
-            .thenMany(
-                Flux.fromIterable(privilegeIds)
+        Mono
+            .from(
+                dslContext
+                    .deleteFrom(USER_PRIVILEGE)
+                    .where(USER_PRIVILEGE.USER_ID.eq(userId)),
+            ).thenMany(
+                Flux
+                    .fromIterable(privilegeIds)
                     .concatMap { pid ->
                         Mono.from(
-                            dslContext.insertInto(USER_PRIVILEGE)
+                            dslContext
+                                .insertInto(USER_PRIVILEGE)
                                 .set(USER_PRIVILEGE.USER_ID, userId)
-                                .set(USER_PRIVILEGE.PRIVILEGE_ID, pid)
+                                .set(USER_PRIVILEGE.PRIVILEGE_ID, pid),
                         )
-                    }
+                    },
             ).then()
-
-
 
     fun findAllPrivileges(): Flux<Privilege> =
         dslContext

--- a/backend/src/main/kotlin/com/example/codex/service/UserService.kt
+++ b/backend/src/main/kotlin/com/example/codex/service/UserService.kt
@@ -23,33 +23,31 @@ class UserService(
         username: String,
         password: String,
         externalId: String,
-    ): Mono<Boolean> = userRepository.save(username, passwordEncoder.encode(password), externalId).log()
-        .doOnNext { user ->
-            println("register user: $user")
-            userPrivilegeRepository.saveAll(
-                Flux.fromIterable(listOf(1L, 2L))
-                    .map { UserPrivilege(userId = user.id!!, privilegeId = it) },
-            ).doOnNext { value -> System.out.println("Saw: " + value) }
-        }.map { it != null }.log()
+    ): Mono<Boolean> =
+        userRepository
+            .save(username, passwordEncoder.encode(password), externalId)
+            .doOnNext { user ->
+                userPrivilegeRepository
+                    .saveAll(
+                        Flux
+                            .fromIterable(listOf(1L, 2L))
+                            .map { UserPrivilege(userId = user.id!!, privilegeId = it) },
+                    )
+            }.map { it != null }
 
-    fun delete(id: Long): Mono<Int> {
-        return userRepository.softDelete(id)
-    }
+    fun delete(id: Long): Mono<Int> = userRepository.softDelete(id)
 
     fun realDelete(id: Long) = userRepository.delete(id)
 
-
     fun findByUsername(username: String) = userRepository.findByUsername(username)
 
-    fun findByExternalId(externalId: String): Mono<User> = userRepository.findByExternalId(externalId).doOnNext { println("found user: $it") }
+    fun findByExternalId(externalId: String): Mono<User> = userRepository.findByExternalId(externalId)
 
     @Transactional
     fun updatePrivileges(
         userId: Long,
         privilegeIds: List<Long>,
-    ): Mono<Void> {
-        return userRepository.updateUserPrivileges(userId, privilegeIds)
-    }
+    ): Mono<Void> = userRepository.updateUserPrivileges(userId, privilegeIds)
 
     fun allPrivileges() = userRepository.findAllPrivileges()
 

--- a/backend/src/test/kotlin/com/example/codex/AbstractControllerITTest.kt
+++ b/backend/src/test/kotlin/com/example/codex/AbstractControllerITTest.kt
@@ -1,0 +1,38 @@
+package com.example.codex
+
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder
+import reactor.core.publisher.Mono
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+
+@SpringBootTest
+abstract class AbstractControllerITTest : AbstractIntegrationTest() {
+    @MockkBean
+    private lateinit var myJwtDecoder: ReactiveJwtDecoder
+
+    companion object {
+        val USERNAME = "user-" + UUID.randomUUID()
+        val EXTERNAL_ID = UUID.randomUUID().toString()
+    }
+
+    @BeforeEach
+    fun setup() {
+        val now = Instant.now()
+        val jwt: Jwt =
+            Jwt
+                .withTokenValue("dummy-token")
+                .header("alg", "none")
+                .subject(EXTERNAL_ID) // jwt.subject
+                .claim("preferred_username", USERNAME) // extra claim used by your app
+                .issuedAt(now)
+                .expiresAt(now.plus(1, ChronoUnit.HOURS))
+                .build()
+        every { myJwtDecoder.decode(any()) } returns Mono.just(jwt)
+    }
+}

--- a/backend/src/test/kotlin/com/example/codex/AbstractIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/example/codex/AbstractIntegrationTest.kt
@@ -1,5 +1,6 @@
 package com.example.codex
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.junit.jupiter.api.BeforeAll
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.DynamicPropertyRegistry
@@ -47,4 +48,6 @@ abstract class AbstractIntegrationTest {
             }
         }
     }
+
+    protected val log = KotlinLogging.logger {}
 }

--- a/backend/src/test/kotlin/com/example/codex/controller/PrivilegeControllerIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/example/codex/controller/PrivilegeControllerIntegrationTest.kt
@@ -2,32 +2,32 @@ package com.example.codex.controller
 
 import com.example.codex.AbstractIntegrationTest
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.BDDMockito.given
+import org.mockito.junit.jupiter.MockitoExtension
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
-import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.request
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.web.reactive.function.BodyInserters
+import reactor.core.publisher.Mono
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
-@SpringBootTest(
-    properties = [
-        // Needed so SecurityConfig.jwtDecoder() can be created in tests
-        "spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://localhost/dummy",
-        // If not already provided by your test config:
-        "frontendUrl=http://localhost:3000"
-    ]
-)
-@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@ExtendWith(value = [MockitoExtension::class])
 class PrivilegeControllerIntegrationTest @Autowired constructor(
-    private val mockMvc: MockMvc,
+    private val webTestClient: WebTestClient,
 ) : AbstractIntegrationTest() {
+
+    @MockBean
+    private lateinit var jwtDecoder: ReactiveJwtDecoder
 
     @Test
     fun `should list privileges`() {
@@ -35,35 +35,37 @@ class PrivilegeControllerIntegrationTest @Autowired constructor(
         val externalId = UUID.randomUUID().toString()
 
         // Register the user through the public API (whitelisted endpoint)
-        mockMvc
-            .perform(
-                post("/api/users/register")
-                    .param("username", username)
-                    .param("password", "password")
-                    .param("externalId", externalId),
+        webTestClient.post()
+            .uri("/api/users/register")
+            .body(
+                BodyInserters.fromFormData("username", username)
+                    .with("password", "password")
+                    .with("externalId", externalId),
             )
-            .andExpect(status().isOk)
+            .exchange()
+            .expectStatus().isOk
+
+        val tokenValue = "dummy-token"
+        val now = Instant.now()
+        val jwt: Jwt =
+            Jwt.withTokenValue(tokenValue)
+                .header("alg", "none")
+                .subject(externalId)
+                .claim("preferred_username", username)
+                .issuedAt(now)
+                .expiresAt(now.plus(1, ChronoUnit.HOURS))
+                .build()
+
+        given(jwtDecoder.decode(anyString())).willReturn(Mono.just(jwt))
 
         // Call the secured endpoint with a mocked JWT user
-        val mvcResult =
-            mockMvc
-                .perform(
-                    get("/api/privileges").with(
-                        jwt().jwt {
-                            it.subject(externalId)                   // -> jwt.subject
-                            it.claim("preferred_username", username) // extra claim if you need it
-                        }
-                    )
-                )
-                .andExpect(request().asyncStarted())
-                .andReturn()
-
-        mockMvc
-            .perform(asyncDispatch(mvcResult))
-            .andExpect(status().isOk)
-            .andDo(print())
-            // if /api/privileges returns a list of objects like [{ "name": "dashboard" }, ...]
-            .andExpect(jsonPath("$[?(@.name == 'dashboard')]").exists())
-            .andExpect(jsonPath("$[?(@.name == 'users')]").exists())
+        webTestClient.get()
+            .uri("/api/privileges")
+            .headers { it.setBearerAuth(tokenValue) }
+            .exchange()
+            .expectStatus().isOk
+            .expectBody()
+            .jsonPath("$[?(@.name == 'dashboard')]").exists()
+            .jsonPath("$[?(@.name == 'users')]").exists()
     }
 }

--- a/backend/src/test/kotlin/com/example/codex/controller/PrivilegeControllerIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/example/codex/controller/PrivilegeControllerIntegrationTest.kt
@@ -1,5 +1,6 @@
 package com.example.codex.controller
 
+import com.example.codex.AbstractControllerITTest
 import com.example.codex.AbstractIntegrationTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -21,51 +22,36 @@ import java.util.UUID
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureWebTestClient
-@ExtendWith(value = [MockitoExtension::class])
-class PrivilegeControllerIntegrationTest @Autowired constructor(
+class PrivilegeControllerIntegrationTest(
+    @Autowired
     private val webTestClient: WebTestClient,
-) : AbstractIntegrationTest() {
-
-    @MockBean
-    private lateinit var jwtDecoder: ReactiveJwtDecoder
-
+) : AbstractControllerITTest() {
     @Test
     fun `should list privileges`() {
-        val username = "user-" + UUID.randomUUID()
-        val externalId = UUID.randomUUID().toString()
+        webTestClient
+            .post()
+            .uri { uriBuilder ->
+                uriBuilder
+                    .path("/api/users/register")
+                    .queryParam("username", USERNAME)
+                    .queryParam("password", "secret")
+                    .queryParam("externalId", EXTERNAL_ID)
+                    .build()
+            }.exchange()
+            .expectStatus()
+            .isOk
 
-        // Register the user through the public API (whitelisted endpoint)
-        webTestClient.post()
-            .uri("/api/users/register")
-            .body(
-                BodyInserters.fromFormData("username", username)
-                    .with("password", "password")
-                    .with("externalId", externalId),
-            )
-            .exchange()
-            .expectStatus().isOk
-
-        val tokenValue = "dummy-token"
-        val now = Instant.now()
-        val jwt: Jwt =
-            Jwt.withTokenValue(tokenValue)
-                .header("alg", "none")
-                .subject(externalId)
-                .claim("preferred_username", username)
-                .issuedAt(now)
-                .expiresAt(now.plus(1, ChronoUnit.HOURS))
-                .build()
-
-        given(jwtDecoder.decode(anyString())).willReturn(Mono.just(jwt))
-
-        // Call the secured endpoint with a mocked JWT user
-        webTestClient.get()
+        webTestClient
+            .get()
             .uri("/api/privileges")
-            .headers { it.setBearerAuth(tokenValue) }
+            .headers { it.setBearerAuth("dummy-token") }
             .exchange()
-            .expectStatus().isOk
+            .expectStatus()
+            .isOk
             .expectBody()
-            .jsonPath("$[?(@.name == 'dashboard')]").exists()
-            .jsonPath("$[?(@.name == 'users')]").exists()
+            .jsonPath("$[?(@.name == 'dashboard')]")
+            .exists()
+            .jsonPath("$[?(@.name == 'users')]")
+            .exists()
     }
 }

--- a/backend/src/test/kotlin/com/example/codex/controller/UserControllerIT.kt
+++ b/backend/src/test/kotlin/com/example/codex/controller/UserControllerIT.kt
@@ -1,74 +1,42 @@
 package com.example.codex.controller
 
-import com.example.codex.AbstractIntegrationTest
+import com.example.codex.AbstractControllerITTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.security.oauth2.jwt.Jwt
-import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.test.web.reactive.server.WebTestClient
-import org.springframework.web.reactive.function.BodyInserters
-import java.time.Instant
-import java.time.temporal.ChronoUnit
-import java.util.UUID
-import org.mockito.BDDMockito.given
-import org.mockito.ArgumentMatchers.anyString
-import org.mockito.junit.jupiter.MockitoExtension
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureWebTestClient
-@ExtendWith(value = [MockitoExtension::class])
-class UserControllerIT @Autowired constructor(
+class UserControllerIT(
+    @Autowired
     private val webTestClient: WebTestClient,
-) : AbstractIntegrationTest() {
-
-    // This replaces your real JwtDecoder bean for the test context
-    @MockBean
-    private lateinit var jwtDecoder: JwtDecoder
-
+) : AbstractControllerITTest() {
     @Test
     fun `registers user and returns it from me`() {
-        val username = "user-" + UUID.randomUUID()
-        val externalId = UUID.randomUUID().toString()
+        webTestClient
+            .post()
+            .uri { uriBuilder ->
+                uriBuilder
+                    .path("/api/users/register")
+                    .queryParam("username", USERNAME)
+                    .queryParam("password", "secret")
+                    .queryParam("externalId", EXTERNAL_ID)
+                    .build()
+            }.exchange()
+            .expectStatus()
+            .isOk
 
-        // 1) create the user through your public API (unauthenticated, whitelisted)
-        webTestClient.post()
-            .uri("/api/users/register")
-            .body(
-                BodyInserters.fromFormData("username", username)
-                    .with("password", "secret")
-                    .with("externalId", externalId)
-            )
-            .exchange()
-            .expectStatus().isOk
-
-        println("externalId: $externalId")
-
-        // 2) Prepare a Jwt that looks like what your app expects
-        val tokenValue = "dummy-token" // can be any string with valid bearer chars
-
-        val now = Instant.now()
-        val jwt: Jwt = Jwt.withTokenValue(tokenValue)
-            .header("alg", "none")
-            .subject(externalId)                      // jwt.subject
-            .claim("preferred_username", username)    // extra claim used by your app
-            .issuedAt(now)
-            .expiresAt(now.plus(1, ChronoUnit.HOURS))
-            .build()
-
-        // 3) Make *any* call to jwtDecoder.decode(...) return our Jwt
-        given(jwtDecoder.decode(anyString())).willReturn(jwt)
-
-        // 4) Call /me with a bearer token; the mocked JwtDecoder will be used
-        webTestClient.get()
+        webTestClient
+            .get()
             .uri("/api/users/me")
-            .headers { it.setBearerAuth(tokenValue) }
+            .headers { it.setBearerAuth("dummy-token") }
             .exchange()
-            .expectStatus().isOk
+            .expectStatus()
+            .isOk
             .expectBody()
-            .jsonPath("$.username").isEqualTo(username)
+            .jsonPath("$.username")
+            .isEqualTo(USERNAME)
     }
 }

--- a/backend/src/test/kotlin/com/example/codex/repository/PrivilegeRepositoryIT.kt
+++ b/backend/src/test/kotlin/com/example/codex/repository/PrivilegeRepositoryIT.kt
@@ -8,36 +8,37 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import reactor.test.StepVerifier
 
-class PrivilegeRepositoryIT
+class PrivilegeRepositoryIT(
     @Autowired
-    constructor(
-        private val privilegeRepository: PrivilegeRepository,
-    ) : AbstractIntegrationTest() {
-        @Test
-        fun `performs CRUD operations`() {
-            // insert
-            val privilege = Privilege(999L, "reports")
-            privilegeRepository.insert(privilege).block()
+    private val privilegeRepository: PrivilegeRepository,
+) : AbstractIntegrationTest() {
+    @Test
+    fun `performs CRUD operations`() {
+        val privilege = Privilege(999L, "reports")
+        val updatedPrivilege = Privilege(999L, "reports-updated")
 
-            // find all
-            val all = privilegeRepository.findAll().collectList().block()!!
-            assertTrue(all.any { it.id == 999L && it.name == "reports" })
+        val test =
+            privilegeRepository
+                .insert(privilege)
+                .then(privilegeRepository.findAll().collectList())
+                .doOnNext { all ->
+                    assertTrue(all.any { it.id == 999L && it.name == "reports" })
+                }.then(privilegeRepository.findById(999L))
+                .doOnNext { found ->
+                    assertNotNull(found)
+                    assertEquals("reports", found.name)
+                }.then(privilegeRepository.update(updatedPrivilege))
+                .then(privilegeRepository.findById(999L))
+                .doOnNext { updated ->
+                    assertEquals("reports-updated", updated.name)
+                }.then(privilegeRepository.delete(999L))
+                .then(privilegeRepository.findById(999L))
 
-            // find by id
-            val found = privilegeRepository.findById(999L).block()
-            assertNotNull(found)
-            assertEquals("reports", found?.name)
-
-            // update
-            val updatedPrivilege = Privilege(999L, "reports-updated")
-            privilegeRepository.update(updatedPrivilege).block()
-            val updated = privilegeRepository.findById(999L).block()
-            assertEquals("reports-updated", updated?.name)
-
-            // delete
-            privilegeRepository.delete(999L).block()
-            val deleted = privilegeRepository.findById(999L).block()
-            assertNull(deleted)
-        }
+        StepVerifier
+            .create(test)
+            .expectNextCount(0)
+            .verifyComplete()
     }
+}

--- a/backend/src/test/kotlin/com/example/codex/repository/UserRepositoryIT.kt
+++ b/backend/src/test/kotlin/com/example/codex/repository/UserRepositoryIT.kt
@@ -3,51 +3,84 @@ package com.example.codex.repository
 import com.example.codex.AbstractIntegrationTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import reactor.core.publisher.Hooks
+import reactor.test.StepVerifier
 
-class UserRepositoryIT
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class UserRepositoryIT(
     @Autowired
-    constructor(
-        private val userRepository: UserRepository,
-    ) : AbstractIntegrationTest() {
-        @Test
-        fun `saves and retrieves user by username`() {
-            userRepository.save("jane", "secret", "ext-jane").block()
-            val user = userRepository.findByUsername("jane").block()
-            assertNotNull(user)
-            assertEquals("jane", user?.username)
-        }
+    private val userRepository: UserRepository,
+) : AbstractIntegrationTest() {
+    @Test
+    fun `saves and retrieves user by username`() {
+        val test =
+            userRepository
+                .save("jane", "secret", "ext-jane")
+                .then(userRepository.findByUsername("jane"))
 
-        @Test
-        fun `soft deletes user`() {
-            userRepository.save("john", "secret", "ext-john").block()
-            val id = userRepository.findByUsername("john").block()?.id!!
-            userRepository.softDelete(id).block()
-            assertNull(userRepository.findById(id).block())
-            assertNull(userRepository.findByUsername("john").block())
-            assertTrue(userRepository.findAll().collectList().block()!!.none { it.id == id })
-        }
-
-        @Test
-        fun `manages user privileges`() {
-            // Ensure first user takes pre-seeded privileges
-            userRepository.save("seed", "pw", "ext-seed").block()
-            userRepository.save("mike", "pw", "ext-mike").block()
-            val mikeId = userRepository.findByUsername("mike").block()!!.id!!
-
-            val privilegeMap = userRepository.findAllPrivileges().collectList().block()!!.associateBy { it.name }
-            val dashboard = privilegeMap["dashboard"]!!
-            val users = privilegeMap["users"]!!
-
-            userRepository.addPrivilege(mikeId, dashboard.id).block()
-            var user = userRepository.findById(mikeId).block()
-            assertEquals(listOf(dashboard), user?.privileges)
-
-            userRepository.updateUserPrivileges(mikeId, listOf(users.id)).block()
-            user = userRepository.findById(mikeId).block()
-            assertEquals(listOf(users), user?.privileges)
-        }
+        StepVerifier
+            .create(test)
+            .assertNext { user ->
+                assertNotNull(user)
+                assertEquals("jane", user.username)
+            }.verifyComplete()
     }
+
+    @Test
+    fun `soft deletes user`() {
+        val test =
+            userRepository
+                .save("john", "secret", "ext-john")
+                .flatMap { userRepository.findByUsername("john") }
+                .flatMap { user ->
+                    println("soft delete user $user")
+                    userRepository
+                        .softDelete(user.id)
+                        .then(userRepository.findById(user.id).hasElement())
+                }
+
+        StepVerifier
+            .create(test)
+            .assertNext { assertEquals(false, it) }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `manages user privileges`() {
+        val test =
+            userRepository
+                .save("seed", "pw", "ext-seed")
+                .then(userRepository.save("mike", "pw", "ext-mike"))
+                .then(userRepository.findByUsername("mike"))
+                .flatMap { mike ->
+                    val mikeId = mike.id
+                    userRepository
+                        .findAllPrivileges()
+                        .collectList()
+                        .flatMap { privileges ->
+                            val privilegeMap = privileges.associateBy { it.name }
+                            val dashboard = privilegeMap["dashboard"]!!
+                            val users = privilegeMap["users"]!!
+
+                            userRepository
+                                .addPrivilege(mikeId, dashboard.id)
+                                .then(userRepository.findById(mikeId))
+                                .doOnNext { user ->
+                                    assertEquals(listOf(dashboard), user.privileges)
+                                }.then(userRepository.updateUserPrivileges(mikeId, listOf(users.id)))
+                                .then(userRepository.findById(mikeId))
+                                .doOnNext { user ->
+                                    assertEquals(listOf(users), user.privileges)
+                                }
+                        }
+                }
+
+        StepVerifier
+            .create(test)
+            .expectNextCount(1)
+            .verifyComplete()
+    }
+}

--- a/backend/src/test/kotlin/com/example/codex/service/UserServiceIT.kt
+++ b/backend/src/test/kotlin/com/example/codex/service/UserServiceIT.kt
@@ -12,31 +12,28 @@ import reactor.test.StepVerifier
 import java.lang.Thread.sleep
 import java.util.UUID
 
-class UserServiceIT
+class UserServiceIT(
     @Autowired
-    constructor(
-        private val userService: UserService,
-        private val userPrivilegeRepository: UserPrivilegeRepository,
-    ) : AbstractIntegrationTest() {
-
+    private val userService: UserService,
+) : AbstractIntegrationTest() {
     @Test
     fun `registers user and appears in all users`() {
         val username = "sarah-${UUID.randomUUID()}"
         val externalId = "ext-$username"
-        val block = userService.allUsers().collectList().block()
-        println("users: $block")
-        userPrivilegeRepository.findAll().subscribe{ println("asdasd $it") }
 
-        val testMono = userService.register(username, "secret", externalId)
-            .then(userService.findByUsername(username))
-            .flatMap { user ->
-                assertNotNull(user, "User should be found after registration")
-                println("finalUser: $user")
-                userService.allUsers()
-                    .any { it.id == user.id }
-            }
+        val testMono =
+            userService
+                .register(username, "secret", externalId)
+                .then(userService.findByUsername(username))
+                .flatMap { user ->
+                    assertNotNull(user, "User should be found after registration")
+                    userService
+                        .allUsers()
+                        .any { it.id == user.id }
+                }
 
-        StepVerifier.create(testMono)
+        StepVerifier
+            .create(testMono)
             .expectNext(true)
             .verifyComplete()
     }
@@ -46,29 +43,34 @@ class UserServiceIT
         val username = "sarah-${UUID.randomUUID()}"
         val externalId = "ext-$username"
 
-        val testMono = userService.register(username, "secret", externalId)
-            .then(userService.findByUsername(username))
-            .flatMap { user ->
-                val id = requireNotNull(user.id)
+        val testMono =
+            userService
+                .register(username, "secret", externalId)
+                .then(userService.findByUsername(username))
+                .flatMap { user ->
+                    val id = requireNotNull(user.id)
 
-                userService.allPrivileges()
-                    .collectList()
-                    .flatMap { privilegeList ->
-                        val byName = privilegeList.associateBy { it.name }
-                        val dashboard = requireNotNull(byName["dashboard"])
-                        val users = requireNotNull(byName["users"])
+                    userService
+                        .allPrivileges()
+                        .collectList()
+                        .flatMap { privilegeList ->
+                            val byName = privilegeList.associateBy { it.name }
+                            val dashboard = requireNotNull(byName["dashboard"])
+                            val users = requireNotNull(byName["users"])
 
-                        userService.updatePrivileges(id, listOf(dashboard.id, users.id))
-                            .then(userService.find(id))
-                            .doOnNext { updated ->
-                                val actual = updated.privileges.toSet()
-                                val expected = setOf(dashboard, users)
-                                assertEquals(expected, actual)
-                            }
-                    }
-            }
+                            userService
+                                .updatePrivileges(id, listOf(dashboard.id, users.id))
+                                .then(userService.find(id))
+                                .doOnNext { updated ->
+                                    val actual = updated.privileges.toSet()
+                                    val expected = setOf(dashboard, users)
+                                    assertEquals(expected, actual)
+                                }
+                        }
+                }
 
-        StepVerifier.create(testMono.log())
+        StepVerifier
+            .create(testMono)
             .expectNextCount(1)
             .verifyComplete()
     }
@@ -78,17 +80,20 @@ class UserServiceIT
         val username = "sarah-${UUID.randomUUID()}"
         val externalId = "ext-$username"
 
-        val testMono = userService.register(username, "secret", externalId)
-            .then(userService.findByUsername(username))
-            .flatMap { user ->
-                val id = requireNotNull(user.id)
+        val testMono =
+            userService
+                .register(username, "secret", externalId)
+                .then(userService.findByUsername(username))
+                .flatMap { user ->
+                    val id = requireNotNull(user.id)
 
-                userService.delete(id)
-                    .then(userService.find(id))   // should be empty after delete
-            }
+                    userService
+                        .delete(id)
+                        .then(userService.find(id)) // should be empty after delete
+                }
 
-        StepVerifier.create(testMono)
+        StepVerifier
+            .create(testMono)
             .verifyComplete()
     }
-
-    }
+}


### PR DESCRIPTION
## Summary
- update the privilege integration test to run with WebTestClient instead of MockMvc for the reactive stack
- mock the reactive JWT decoder and build a test token to exercise the secured endpoint

## Testing
- ❌ `./gradlew test --no-daemon --tests com.example.codex.controller.PrivilegeControllerIntegrationTest --console=plain` (hangs before completion in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cfbaebe34832bac9cb0f470ba0adc)