### PR TITLE
Add rollback support for integration tests

### DIFF
--- a/backend/src/main/kotlin/com/example/codex/config/Beans.kt
+++ b/backend/src/main/kotlin/com/example/codex/config/Beans.kt
@@ -12,6 +12,7 @@ import org.springframework.r2dbc.connection.R2dbcTransactionManager
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.transaction.ReactiveTransactionManager
+import org.springframework.transaction.reactive.TransactionalOperator
 
 @Configuration
 class Beans {
@@ -31,4 +32,8 @@ class Beans {
     @Bean
     fun reactiveTransactionManager(connectionFactory: ConnectionFactory): ReactiveTransactionManager =
         R2dbcTransactionManager(connectionFactory)
+
+    @Bean
+    fun transactionalOperator(reactiveTransactionManager: ReactiveTransactionManager): TransactionalOperator =
+        TransactionalOperator.create(reactiveTransactionManager)
 }

--- a/backend/src/test/kotlin/com/example/codex/AbstractIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/example/codex/AbstractIntegrationTest.kt
@@ -1,14 +1,21 @@
 package com.example.codex
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import org.reactivestreams.Publisher
+import org.springframework.beans.factory.annotation.Autowired
 import org.junit.jupiter.api.BeforeAll
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
+import org.springframework.transaction.reactive.TransactionalOperator
 import org.testcontainers.containers.PostgreSQLContainer
+import reactor.core.publisher.Flux
 
 @SpringBootTest
 abstract class AbstractIntegrationTest {
+    @Autowired
+    private lateinit var transactionalOperator: TransactionalOperator
+
     companion object {
         private val useTestcontainers = System.getenv("DISABLE_TESTCONTAINERS") != "true"
         private val postgres =
@@ -50,4 +57,10 @@ abstract class AbstractIntegrationTest {
     }
 
     protected val log = KotlinLogging.logger {}
+
+    protected fun <T : Any> rollback(publisher: Publisher<T>): Flux<T> =
+        transactionalOperator.execute<T> { status ->
+            status.setRollbackOnly()
+            Flux.from(publisher)
+        }
 }

--- a/backend/src/test/kotlin/com/example/codex/service/UserServiceIT.kt
+++ b/backend/src/test/kotlin/com/example/codex/service/UserServiceIT.kt
@@ -33,7 +33,7 @@ class UserServiceIT(
                 }
 
         StepVerifier
-            .create(testMono)
+            .create(rollback(testMono))
             .expectNext(true)
             .verifyComplete()
     }
@@ -70,7 +70,7 @@ class UserServiceIT(
                 }
 
         StepVerifier
-            .create(testMono)
+            .create(rollback(testMono))
             .expectNextCount(1)
             .verifyComplete()
     }
@@ -93,7 +93,7 @@ class UserServiceIT(
                 }
 
         StepVerifier
-            .create(testMono)
+            .create(rollback(testMono))
             .verifyComplete()
     }
 }


### PR DESCRIPTION
## Summary
- add a transactional operator bean to support reactive rollbacks
- wrap integration test publishers with a rollback helper so each subscription rolls back automatically
- apply rollback helper in user service integration tests

## Testing
- ./gradlew test --no-daemon --console=plain *(fails: PostgreSQL authentication for user `codex` in test environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e14a737ec832ba65ab5db13d9ccb6)