### PR TITLE
Fix Keycloak health probes

### DIFF
--- a/helm/codex/templates/keycloak.yaml
+++ b/helm/codex/templates/keycloak.yaml
@@ -61,6 +61,7 @@ spec:
             - --import-realm
             - --hostname-strict=false
             - --http-enabled=true
+            - --health-enabled=true
           env:
             - name: KEYCLOAK_ADMIN
               valueFrom:
@@ -93,16 +94,18 @@ spec:
           ports:
             - name: http
               containerPort: 8080
+            - name: http-management
+              containerPort: 9000
           livenessProbe:
             httpGet:
               path: /health/live
-              port: 8080
+              port: 9000
             initialDelaySeconds: 30
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /health/ready
-              port: 8080
+              port: 9000
             initialDelaySeconds: 30
             periodSeconds: 10
           volumeMounts:


### PR DESCRIPTION
## Summary
- enable Keycloak's health endpoints and expose the management port in the deployment
- point liveness and readiness probes to the management health endpoints

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e54632768832bb295da8f3d1939a1)