### PR TITLE
Add Gradle plugin to reuse single Spring test context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 ### IntelliJ IDEA ###
 .idea
+backend/buildSrc/build

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
     id("nu.studer.jooq") version "8.2"
     id("com.diffplug.spotless") version "6.25.0"
     id("com.example.codex.testcontainers")
+    id("com.example.codex.spring-context")
     jacoco
 }
 

--- a/backend/buildSrc/src/main/kotlin/SingleSpringContextPlugin.kt
+++ b/backend/buildSrc/src/main/kotlin/SingleSpringContextPlugin.kt
@@ -1,0 +1,13 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.testing.Test
+
+class SingleSpringContextPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        project.tasks.withType(Test::class.java).configureEach {
+            // Limit Spring's context cache to a single entry so the same application context is reused
+            // across all test classes.
+            systemProperty("spring.test.context.cache.maxSize", "1")
+        }
+    }
+}

--- a/backend/buildSrc/src/main/resources/META-INF/gradle-plugins/com.example.codex.spring-context.properties
+++ b/backend/buildSrc/src/main/resources/META-INF/gradle-plugins/com.example.codex.spring-context.properties
@@ -1,0 +1,1 @@
+implementation-class=SingleSpringContextPlugin


### PR DESCRIPTION
## Summary
- add a Gradle test plugin that caps the Spring test context cache to a single entry so all tests share one application context
- apply the plugin to the backend build for consistent Spring context reuse during testing

## Testing
- ./gradlew test --no-daemon --console=plain *(fails: ConfigurationPropertiesBindException assertions in integration tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fb490c164832b857b68365847e2ab)